### PR TITLE
APU fixes and additional palettes

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -147,7 +147,7 @@ parameter CONF_STR3 = {
 	"O8,Aspect ratio,4:3,16:9;",
 	"O13,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
 	"O4,Hide overscan,OFF,ON;",
-	"OCE,Palette,Smooth,Unsaturated-V6,FCEUX,NES Classic,Composite Direct,PC-10,PVM,Wavebeam;",
+	"OCF,Palette,Smooth,Unsat.,FCEUX,NES Classic,Composite,PC-10,PVM,Wavebeam,Real,Sony CXA,YUV,Greyscale,Rockman9,Nintendulator;",
 	"-;",
 	"O9,Swap joysticks,NO,YES;",
 	"OA,Multitap,Disabled,Enabled;",
@@ -169,7 +169,7 @@ wire [31:0] status;
 wire arm_reset = status[0];
 wire mirroring_osd = status[5];
 wire hide_overscan = status[4];
-wire [2:0] palette2_osd = status[14:12];
+wire [3:0] palette2_osd = status[15:12];
 wire joy_swap = status[9];
 wire fds_swap_invert = status[16];
 `ifdef DEBUG_AUDIO

--- a/apu.sv
+++ b/apu.sv
@@ -288,7 +288,7 @@ module TriangleChan(input clk, input ce, input reset,
       SeqPos <= SeqPos + 1'd1;
   end
   // Generate the output
-  assign Sample = SeqPos[3:0] ^ {4{~SeqPos[4]}};
+  assign Sample = (Period > 2) ? SeqPos[3:0] ^ {4{~SeqPos[4]}} : 4'b0000;
   //
 endmodule
 

--- a/apu.sv
+++ b/apu.sv
@@ -137,7 +137,7 @@ always @(posedge clk) if (reset) begin
   // Count down the square timer...
   if (TimerCtr == 0) begin
     // Timer was clocked
-    TimerCtr <= {Period, 1'b0};
+    TimerCtr <= {Period, 1'b1};
     SeqPos <= SeqPos - 1'd1;
   end else begin
     TimerCtr <= TimerCtr - 1'd1;

--- a/video.sv
+++ b/video.sv
@@ -131,14 +131,14 @@ wire [15:0] pal_wavebeam_lut[64] = '{
 
 // Real by Squire
 wire [15:0] pal_real_lut[64] = '{
-	'h318C, 'h3C80, 'h4C00, 'h4406, 'h340B, 'h180D, 'h000C, 'h0049,
-	'h0065, 'h00A4, 'h0100, 'h18E0, 'h24E0, 'h0000, 'h0421, 'h0421,
-	'h56B5, 'h6542, 'h7CA3, 'h748C, 'h5C15, 'h2859, 'h0479, 'h00F3,
-	'h014C, 'h0188, 'h01E0, 'h29C0, 'h41C0, 'h0421, 'h0421, 'h0421,
-	'h7FFF, 'h7E68, 'h7DAB, 'h7D93, 'h7D9A, 'h499F, 'h299F, 'h1A5E,
-	'h02B8, 'h0B12, 'h174A, 'h4B04, 'h6AE3, 'h2529, 'h0421, 'h0421,
-	'h7FFF, 'h7F34, 'h7ED4, 'h7ED8, 'h7EDC, 'h631F, 'h56FF, 'h4F5F,
-	'h4B9F, 'h4FBC, 'h53D9, 'h73B4, 'h7F94, 'h5AD6, 'h0421, 'h0421
+	'h35AD, 'h4480, 'h5400, 'h4808, 'h380E, 'h200F, 'h000E, 'h004C,
+	'h0088, 'h00C6, 'h0140, 'h2100, 'h3100, 'h0000, 'h0842, 'h0842,
+	'h5EF7, 'h6D64, 'h7CE7, 'h7890, 'h6018, 'h385A, 'h109A, 'h0915,
+	'h014F, 'h018B, 'h0220, 'h35C0, 'h4DC0, 'h1084, 'h0842, 'h0842,
+	'h7FFF, 'h7E89, 'h7E31, 'h7DB8, 'h7D5F, 'h5D9F, 'h3DFF, 'h1E5F,
+	'h02BB, 'h1334, 'h2769, 'h5325, 'h7703, 'h2D6B, 'h0842, 'h0842,
+	'h7FFF, 'h7F56, 'h7F18, 'h7EFD, 'h7EDF, 'h76FF, 'h631F, 'h575F,
+	'h4BBF, 'h53DE, 'h63F8, 'h7BD5, 'h7FB4, 'h6318, 'h1084, 'h0842
 };
 
 // Sony CXA by FirebrandX

--- a/video.sv
+++ b/video.sv
@@ -10,7 +10,7 @@ module video
 	input        forced_scandoubler,
 	input  [2:0] scale,
 	input        hide_overscan,
-	input  [2:0] palette,
+	input  [3:0] palette,
 
 	output       ce_pix,
 
@@ -129,6 +129,78 @@ wire [15:0] pal_wavebeam_lut[64] = '{
 	'h539D, 'h53BA, 'h5BD7, 'h67D6, 'h7BB6, 'h5EF7, 'h0000, 'h0000
 };
 
+// Real by Squire
+wire [15:0] pal_real_lut[64] = '{
+	'h318C, 'h3C80, 'h4C00, 'h4406, 'h340B, 'h180D, 'h000C, 'h0049,
+	'h0065, 'h00A4, 'h0100, 'h18E0, 'h24E0, 'h0000, 'h0421, 'h0421,
+	'h56B5, 'h6542, 'h7CA3, 'h748C, 'h5C15, 'h2859, 'h0479, 'h00F3,
+	'h014C, 'h0188, 'h01E0, 'h29C0, 'h41C0, 'h0421, 'h0421, 'h0421,
+	'h7FFF, 'h7E68, 'h7DAB, 'h7D93, 'h7D9A, 'h499F, 'h299F, 'h1A5E,
+	'h02B8, 'h0B12, 'h174A, 'h4B04, 'h6AE3, 'h2529, 'h0421, 'h0421,
+	'h7FFF, 'h7F34, 'h7ED4, 'h7ED8, 'h7EDC, 'h631F, 'h56FF, 'h4F5F,
+	'h4B9F, 'h4FBC, 'h53D9, 'h73B4, 'h7F94, 'h5AD6, 'h0421, 'h0421
+};
+
+// Sony CXA by FirebrandX
+wire [15:0] pal_sonycxa_lut[64] = '{
+	'h2D6B, 'h4480, 'h4C40, 'h4005, 'h280B, 'h080F, 'h002F, 'h006B,
+	'h00A6, 'h00E1, 'h00E0, 'h10E0, 'h2CC0, 'h0000, 'h0000, 'h0000,
+	'h5294, 'h7540, 'h7CE2, 'h70AC, 'h4C75, 'h207A, 'h00BA, 'h0115,
+	'h016D, 'h01C5, 'h01E0, 'h29E0, 'h55A0, 'h0000, 'h0000, 'h0000,
+	'h7FFF, 'h7E83, 'h7E2B, 'h7DD6, 'h799F, 'h499F, 'h1DDF, 'h065F,
+	'h02D8, 'h0B2F, 'h2747, 'h5342, 'h7EE0, 'h2108, 'h0000, 'h0000,
+	'h7FFF, 'h7F74, 'h7F37, 'h7F1C, 'h7EFF, 'h6AFF, 'h571F, 'h475F,
+	'h437D, 'h4BB8, 'h5BB5, 'h6FB2, 'h7F92, 'h56B5, 'h0000, 'h0000
+};
+
+// YUV from Nestopia
+wire [15:0] pal_yuv_lut[64] = '{
+	'h318C, 'h44A0, 'h5042, 'h5007, 'h3C0B, 'h200D, 'h000D, 'h006A,
+	'h00C6, 'h0121, 'h0140, 'h0520, 'h2500, 'h0000, 'h0000, 'h0000,
+	'h56B5, 'h6D62, 'h7D08, 'h7C8E, 'h6474, 'h3C76, 'h10D6, 'h0133,
+	'h01AD, 'h0207, 'h0241, 'h1A20, 'h45E0, 'h0000, 'h0000, 'h0000,
+	'h7FFF, 'h7ECC, 'h7E52, 'h7DD8, 'h7DBE, 'h65BF, 'h3A1F, 'h127D,
+	'h02F7, 'h0371, 'h1B8B, 'h4388, 'h6F29, 'h2529, 'h0000, 'h0000,
+	'h7FFF, 'h7F78, 'h7F5A, 'h7F3D, 'h7F1F, 'h771F, 'h633F, 'h537E,
+	'h4B9C, 'h4BB9, 'h57D7, 'h67D6, 'h7BB6, 'h5EF7, 'h0000, 'h0000
+};
+
+// Greyscale
+wire [15:0] pal_greyscale_lut[64] = '{
+	'h39CE, 'h1CE7, 'h18C6, 'h14A5, 'h1CE7, 'h18C6, 'h18C6, 'h0842,
+	'h0C63, 'h1CE7, 'h2108, 'h1CE7, 'h1CE7, 'h0000, 'h0421, 'h0421,
+	'h5AD6, 'h3DEF, 'h35AD, 'h318C, 'h39CE, 'h35AD, 'h35AD, 'h318C,
+	'h39CE, 'h3DEF, 'h4631, 'h4210, 'h3DEF, 'h18C6, 'h0421, 'h0421,
+	'h7BDE, 'h5EF7, 'h5294, 'h4A52, 'h5294, 'h4E73, 'h5294, 'h56B5,
+	'h5AD6, 'h5EF7, 'h6739, 'h6318, 'h6318, 'h318C, 'h0421, 'h0421,
+	'h7BDE, 'h77BD, 'h6F7B, 'h6739, 'h6739, 'h6739, 'h6739, 'h6B5A,
+	'h6F7B, 'h6F7B, 'h6F7B, 'h6F7B, 'h6F7B, 'h5EF7, 'h0421, 'h0421
+};
+
+// Rockman9 Palette
+wire [15:0] pal_rockman9_lut[64] = '{
+	'h39CE, 'h5400, 'h4464, 'h4C08, 'h3811, 'h0815, 'h0014, 'h002F,
+	'h00A8, 'h0100, 'h0140, 'h08E0, 'h2CE3, 'h0000, 'h0000, 'h0000,
+	'h5EF7, 'h75C0, 'h74E4, 'h7810, 'h5C17, 'h2C1C, 'h00BB, 'h0539,
+	'h01D1, 'h0240, 'h02A0, 'h1E40, 'h4600, 'h0000, 'h0000, 'h0000,
+	'h7FFF, 'h7EE7, 'h7E4B, 'h7E34, 'h7DFE, 'h59DF, 'h31DF, 'h1E7F,
+	'h1EFE, 'h0B50, 'h2769, 'h4FEB, 'h6FA0, 'h294A, 'h0000, 'h0000,
+	'h7FFF, 'h7F95, 'h7F58, 'h7F3A, 'h7F1F, 'h6F1F, 'h5AFF, 'h577F,
+	'h539F, 'h53FC, 'h5FD5, 'h67F6, 'h7BF3, 'h4E73, 'h0000, 'h0000
+};
+
+// Nintendulator NTSC
+wire [15:0] pal_nintendulator_lut[64] = '{
+	'h318C, 'h4CA0, 'h6022, 'h5C07, 'h440C, 'h200F, 'h000F, 'h006C,
+	'h00E6, 'h0121, 'h0160, 'h0140, 'h2900, 'h0000, 'h0000, 'h0000,
+	'h56B5, 'h7980, 'h7CE7, 'h7C6F, 'h7035, 'h4059, 'h08B9, 'h0134,
+	'h01CD, 'h0246, 'h0260, 'h1660, 'h4E00, 'h0000, 'h0000, 'h0000,
+	'h7FFF, 'h7ECA, 'h7E31, 'h7DB9, 'h7D7F, 'h699F, 'h31FF, 'h027F,
+	'h0318, 'h0390, 'h0BC9, 'h3FA6, 'h7746, 'h2529, 'h0000, 'h0000,
+	'h7FFF, 'h7F77, 'h7F5A, 'h7F1D, 'h7EFF, 'h76FF, 'h633F, 'h4F5F,
+	'h439C, 'h43D9, 'h53F6, 'h67F5, 'h7BB5, 'h5AD6, 'h0000, 'h0000
+};
+
 reg [14:0] pixel;
 reg HBlank_r, VBlank_r;
 
@@ -144,6 +216,12 @@ always @(posedge clk) begin
 			5: pixel <= pal_pc10_lut[color][14:0];
 			6: pixel <= pal_pvm_lut[color][14:0];
 			7: pixel <= pal_wavebeam_lut[color][14:0];
+			8: pixel <= pal_real_lut[color][14:0];
+			9: pixel <= pal_sonycxa_lut[color][14:0];
+			10: pixel <= pal_yuv_lut[color][14:0];
+			11: pixel <= pal_greyscale_lut[color][14:0];
+			12: pixel <= pal_rockman9_lut[color][14:0];
+			13: pixel <= pal_nintendulator_lut[color][14:0];
 			default:pixel <= pal_smooth_lut[color][14:0];
 		endcase
 	


### PR DESCRIPTION
I fixed the square wave being off because of an off-by-one error and also the high pitched squeal from HDMI audio in some games (MegaMan 2) caused by the unfiltered triangle generating supersonic audio. I also added a few more popular palettes that people have been asking me for. They're more saturated for people who like a richer look. If I ever have to add more in the future, I will see if I can find a better way to deal with them.