### PR TITLE
Mapper Refactor - Phase 2

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -382,7 +382,7 @@ always @(posedge clk) nes_ce <= nes_ce + 1'd1;
 NES nes
 (
 	clk, reset_nes, run_nes,
-	mapper_flags,
+	downloading ? 25'd0 : mapper_flags,
 	sample, color,
 	joypad_strobe, joypad_clock, {powerpad_d4[0],powerpad_d3[0],joypad_bits2[0],joypad_bits[0]}, mic,
 	fds_swap,

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This is an FPGA implementation of the NES/Famicom based on [FPGANES](https://git
 
 ## Features
  * Supports saves for most ROM games (FDS saves not currently supported)
- * FDS Support
+ * FDS Support with expansion audio
  * Multiple Palette options
- * Supports expansion audio from FDS and special mappers
- * Supports many popular mappers including VRC6-7, MMC0-5, and UNROM 512
+ * Supports expansion audio from mappers including VRC6 & 7, MMC5 and Sunsoft 5b
+ * Supports many popular mappers including VRC1-7, MMC0-5, and many more (see below)
+ * Supports large games such as Legend of Link and Rockman Minus Infinity
 
 ## Installation
 Copy the NES_\*.rbf file to the root of the SD card. Create a **NES** folder on the root of the card, and place NES roms (\*.NES) inside this folder. The ROMs must have an iNES or NES2.0 header, which most already do. NES2.0 headers are prefered for the best accuracy. To have a game ROM load automatically upon starting the core and place it in the **NES** folder.
@@ -16,8 +17,8 @@ Copy the NES_\*.rbf file to the root of the SD card. Create a **NES** folder on 
 - boot2.rom = FDS image file.  Requires boot0.rom (BIOS)
 - boot3.rom = FDS BIOS file.  Use instead of boot0.rom.  Will be used for any FDS images loaded, and will start running without an FDS image on core start
 
-### Famicom Disk System Usage
-Before loading \*.FDS files, first you must load the official, unpatched FDS BIOS. The BIOS file should be renamed to boot0.rom or boot3.rom and placed in the same folder as the ROMs (NES).  Alternatively, it can be loaded from the OSD if it boot0.rom and boot3.rom don't exist. After loading the core, the bios will be loaded and you may select an FDS image. By default, the NES core will swap disk sides for you automatically. To suppress this behavior, hold the SELECT button on the player 1 controller.  The Disk Swap OSD options inverts this behavior (press Select to swap disks). Currently, saves are not supported for FDS games.
+## Famicom Disk System Usage
+Before loading \*.FDS files, you must first load the official, unpatched FDS BIOS. The BIOS file should be renamed to boot0.rom or boot3.rom and placed in the same folder as the ROMs (NES).  Alternatively, it can be loaded from the OSD if boot0.rom and boot3.rom don't exist. After loading the core and the bios you may select an FDS image. By default, the NES core will swap disk sides for you automatically. To suppress this behavior, hold the FDS button on the player 1 controller. The "Disk Swap" OSD option inverts this behavior (press FDS to swap disks). Currently, saves are not supported for FDS games.
 
 ## Saving and Loading
 The battery backed RAM (Save RAM) for the NES does not write to disk automatically. When loading a game, you must select **Load Backup RAM** from the OSD menu. After saving in your game, you must then write the RAM to the SD card by selecting **Save Backup RAM** from the menu. If you do not save your RAM to disk, the contents will be lost next time you restart the core or switch games.

--- a/cart.sv
+++ b/cart.sv
@@ -997,9 +997,7 @@ Mapper165 map165(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b),
-	//special ports
-	.chr_read(chr_read)
+	.audio_b    (audio_out_b)
 );
 
 //*****************************************************************************//
@@ -1023,7 +1021,6 @@ Mapper218 map218(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
-	.chr_read   (chr_read),
 	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),

--- a/cart.sv
+++ b/cart.sv
@@ -68,7 +68,7 @@ module cart_top (
 // 	output       CIRAM_ce_n,
 // 	input        ROMSEL_n,       // ~(cpu_addr[15] & m2)
 // 	output       IRQ_n,
-// 	input        CPU_rnw,        // 
+// 	input        CPU_rnw,        //
 // 	input [14:0] CPU_addr,       // CPU Bus Address
 // 	input  [7:0] CPU_data_in,    // CPU BUS Data inout.
 // 	output [7:0] CPU_data_out,   // CPU BUS Data inout.
@@ -76,10 +76,10 @@ module cart_top (
 // 	input        clk_sys         // Only on 72 pin connectors, 21mhz NTSC or 27mhz PAL
 // );
 
-trireg prg_allow_b, vram_a10_b, vram_ce_b, chr_allow_b, irq_b;
-trireg [21:0] prg_addr_b, chr_addr_b;
-trireg [15:0] flags_out_b, audio_out_b;
-trireg [7:0] prg_dout_b, chr_dout_b;
+tri0 prg_allow_b, vram_a10_b, vram_ce_b, chr_allow_b, irq_b;
+tri0 [21:0] prg_addr_b, chr_addr_b;
+tri0 [15:0] flags_out_b, audio_out_b;
+tri1 [7:0] prg_dout_b, chr_dout_b;
 
 // This mapper used to be default if no other mapper was found
 // It seems MMC0 is handled by map28. Does it have any purpose?
@@ -99,6 +99,7 @@ MMC0 mmc0(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -129,6 +130,7 @@ MMC1 mmc1(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -160,6 +162,7 @@ Mapper28 map28(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_dout_b (chr_dout_b), // Special port
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
@@ -191,6 +194,7 @@ Mapper30 map30(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -221,6 +225,7 @@ Mapper32 map32(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -251,6 +256,7 @@ MMC2 mmc2(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -286,6 +292,7 @@ MMC3 mmc3 (
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -316,6 +323,7 @@ MMC4 mmc4(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -346,6 +354,7 @@ MMC5 mmc5(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -382,6 +391,7 @@ Mapper13 map13(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -412,6 +422,7 @@ Mapper15 map15(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -445,6 +456,7 @@ Mapper16 map16(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -481,6 +493,7 @@ Mapper18 map18(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -511,6 +524,7 @@ Mapper34 map34(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -541,6 +555,7 @@ Mapper41 map41(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -571,6 +586,7 @@ Mapper42 map42(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -601,6 +617,7 @@ Mapper65 map65(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -632,6 +649,7 @@ Mapper66 map66(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -662,6 +680,7 @@ Mapper67 map67(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -692,6 +711,7 @@ Mapper68 map68(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -722,6 +742,7 @@ Mapper69 map69(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -752,6 +773,7 @@ Mapper71 map71(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -782,6 +804,7 @@ Mapper72 map72(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -812,6 +835,7 @@ Mapper77 map77(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -842,6 +866,7 @@ Mapper78 map78(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -872,6 +897,7 @@ Mapper79 map79(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -902,6 +928,7 @@ Mapper89 map89(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -932,6 +959,7 @@ Mapper107 map107(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -962,13 +990,16 @@ Mapper165 map165(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	//special ports
+	.chr_read(chr_read)
 );
 
 //*****************************************************************************//
@@ -992,6 +1023,8 @@ Mapper218 map218(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1022,6 +1055,7 @@ Mapper228 map228(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1054,6 +1088,7 @@ Mapper234 map234(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1084,6 +1119,7 @@ Rambo1 rambo1(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1114,6 +1150,7 @@ NesEvent nesev(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1121,8 +1158,8 @@ NesEvent nesev(
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
 	.audio_b    (audio_out_b)
-);	
-	
+);
+
 
 //*****************************************************************************//
 // Name   : Konami VRC-1                                                       //
@@ -1145,6 +1182,7 @@ VRC1 vrc1(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1175,6 +1213,7 @@ VRC3 vrc3(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1205,6 +1244,7 @@ VRC24 vrc24(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1235,6 +1275,7 @@ VRC6 vrc6(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1265,6 +1306,7 @@ VRC7 vrc7(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1295,6 +1337,7 @@ N106 n106(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1325,6 +1368,7 @@ MapperFDS mapfds(
 	.prg_allow_b(prg_allow_b),
 	.chr_ain    (chr_ain),
 	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
 	.chr_allow_b(chr_allow_b),
 	.vram_a10_b (vram_a10_b),
 	.vram_ce_b  (vram_ce_b),
@@ -1372,7 +1416,7 @@ always @* begin
 	// Currently only used for Mapper 16 EEPROM. Expand if needed.
 	{mapper_addr, mapper_data_out, mapper_prg_write, mapper_ovr} = (me[159] | me[16]) ?
 		{map16_mapper_addr, map16_data_out, map16_prg_write, map16_ovr} : 25'd0;
-		
+
 	// Behavior helper flags
 	{prg_conflict, prg_open_bus, has_chr_dout} = {flags_out_b[2], flags_out_b[1], flags_out_b[0]};
 

--- a/cart.sv
+++ b/cart.sv
@@ -1,5 +1,20 @@
 // Mapper top level selection
 
+// Notes by Kitrinx:
+// This module uses bidirectional ports to handle the data out of each mapper.
+// Although FPGA's do not use bidirectional wiring internally, the alternative is
+// creating a tenticle-monster of wires for each mapper, and muxing them all together.
+// As it stands, the compiler will efficiently do it for us with much more readable and
+// manageable code if we do it this way, and since not more than one mapper can be active
+// at a time, there will be no conflicts.
+
+// SDRAM Locations for various RAM types:
+// PRG       = 0....
+// CHR       = 10...
+// CHR-VRAM  = 1100
+// CPU-RAM   = 1110
+// CARTRAM   = 1111
+
 module cart_top (
 	input             clk,
 	input             ce,
@@ -33,236 +48,1279 @@ module cart_top (
 	output reg        mapper_prg_write,
 	output reg        mapper_ovr,
 	output reg        irq,
+	input      [15:0] audio_in,
 	output reg [15:0] audio,          // External Audio
 	input             fds_swap        // FDS Disk Swap Pause
 );
 
-wire mmc0_prg_allow, mmc0_vram_a10, mmc0_vram_ce, mmc0_chr_allow;
-wire [21:0] mmc0_prg_addr, mmc0_chr_addr;
-MMC0 mmc0(clk, ce, flags, prg_ain, mmc0_prg_addr, prg_read, prg_write, prg_din, mmc0_prg_allow, chr_ain, mmc0_chr_addr,
-	mmc0_chr_allow, mmc0_vram_a10, mmc0_vram_ce);
+tri prg_allow_b, vram_a10_b, vram_ce_b, chr_allow_b, irq_b;
+tri [21:0] prg_addr_b, chr_addr_b;
+tri [15:0] flags_out_b, audio_out_b;
+tri [7:0] prg_dout_b, chr_dout_b;
 
-wire mmc1_prg_allow, mmc1_vram_a10, mmc1_vram_ce, mmc1_chr_allow;
-wire [21:0] mmc1_prg_addr, mmc1_chr_addr;
-MMC1 mmc1(clk, ce, reset, flags, prg_ain, mmc1_prg_addr, prg_read, prg_write, prg_din, mmc1_prg_allow, chr_ain, mmc1_chr_addr,
-	mmc1_chr_allow, mmc1_vram_a10, mmc1_vram_ce);
+// This mapper used to be default if no other mapper was found
+// It seems MMC0 is handled by map28. Does it have any purpose?
+MMC0 mmc0(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (1'b0),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map28_prg_allow, map28_open_bus, map28_conflict, map28_vram_a10, map28_vram_ce, map28_chr_allow;
-wire [21:0] map28_prg_addr, map28_chr_addr;
-wire [7:0]  map28_chr_dout;
-wire  map28_has_chr_dout;
-Mapper28 map28(clk, ce, reset, flags, prg_ain, map28_prg_addr, prg_read, prg_write, prg_din, map28_prg_allow, map28_open_bus, map28_conflict,
-	chr_ain, map28_chr_addr, map28_chr_dout, map28_has_chr_dout, map28_chr_allow, map28_vram_a10, map28_vram_ce);
+//*****************************************************************************//
+// Name   : MMC1                                                               //
+// Mappers: 1                                                                  //
+// Status : Working                                                            //
+// Notes  :                                                                    //
+// Games  : Simon's Quest                                                      //
+//*****************************************************************************//
+MMC1 mmc1(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[1]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map30_prg_allow, map30_vram_a10, map30_vram_ce, map30_chr_allow;
-wire [21:0] map30_prg_addr, map30_chr_addr;
-Mapper30 map30(clk, ce, reset, flags, prg_ain, map30_prg_addr, prg_read, prg_write, prg_din, map30_prg_allow,
-	chr_ain, map30_chr_addr, map30_chr_allow, map30_vram_a10, map30_vram_ce);
+//*****************************************************************************//
+// Name   : Tepples                                                            //
+// Mappers: 0, 2, 3, 7, 28, 94, 180                                            //
+// Status : Working                                                            //
+// Notes  : This mapper relies on open bus and bus conflict behavior.          //
+// Games  : Donkey Kong                                                        //
+//*****************************************************************************//
+wire mapper28_en = me[0] | me[2] | me[3] | me[7] | me[94] | me[180] | me[185] | me[28];
+Mapper28 map28(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (mapper28_en & ~reset),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_dout_b (chr_dout_b), // Special port
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map32_prg_allow, map32_vram_a10, map32_vram_ce, map32_chr_allow;
-wire [21:0] map32_prg_addr, map32_chr_addr;
-Mapper32 map32(clk, ce, reset, flags, prg_ain, map32_prg_addr, prg_read, prg_write, prg_din, map32_prg_allow,
-	chr_ain, map32_chr_addr, map32_chr_allow, map32_vram_a10, map32_vram_ce);
+//*****************************************************************************//
+// Name   : UNROM 512                                                          //
+// Mappers: 30                                                                 //
+// Status : No Self Flashing/Needs testing                                     //
+// Notes  : Homebrew mapper                                                    //
+// Games  : ?                                                                  //
+//*****************************************************************************//
+Mapper30 map30(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[30]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire mmc2_prg_allow, mmc2_vram_a10, mmc2_vram_ce, mmc2_chr_allow;
-wire [21:0] mmc2_prg_addr, mmc2_chr_addr;
-MMC2 mmc2(clk, ppu_ce, reset, flags, prg_ain, mmc2_prg_addr, prg_read, prg_write, prg_din, mmc2_prg_allow,
-	chr_read, chr_ain, mmc2_chr_addr, mmc2_chr_allow, mmc2_vram_a10, mmc2_vram_ce);
+//*****************************************************************************//
+// Name   : Mapper 32                                                          //
+// Mappers: 32                                                                 //
+// Status : Needs evaluation                                                   //
+// Notes  :                                                                    //
+// Games  : Image Fight                                                        //
+//*****************************************************************************//
+Mapper32 map32(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[32]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire mmc3_prg_allow, mmc3_vram_a10, mmc3_vram_ce, mmc3_chr_allow, mmc3_irq;
-wire [21:0] mmc3_prg_addr, mmc3_chr_addr;
-MMC3 mmc3(clk, ppu_ce, reset, flags, prg_ain, mmc3_prg_addr, prg_read, prg_write, prg_din, mmc3_prg_allow,
-	chr_ain, mmc3_chr_addr, mmc3_chr_allow, mmc3_vram_a10, mmc3_vram_ce, mmc3_irq);
+//*****************************************************************************//
+// Name   : MMC2                                                               //
+// Mappers: 9                                                                  //
+// Status :                                                                    //
+// Notes  : Working                                                            //
+// Games  : Mike Tyson's Punch-Out                                             //
+//*****************************************************************************//
+MMC2 mmc2(
+	.clk        (clk),
+	.ce         (ppu_ce),
+	.enable     (me[9]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire mmc4_prg_allow, mmc4_vram_a10, mmc4_vram_ce, mmc4_chr_allow;
-wire [21:0] mmc4_prg_addr, mmc4_chr_addr;
-MMC4 mmc4(clk, ppu_ce, reset, flags, prg_ain, mmc4_prg_addr, prg_read, prg_write, prg_din, mmc4_prg_allow,
-	chr_read, chr_ain, mmc4_chr_addr, mmc4_chr_allow, mmc4_vram_a10, mmc4_vram_ce);
+//*****************************************************************************//
+// Name   : MMC3                                                               //
+// Mappers: 4, 33, 37, 47, 48, 74, 76, 80, 82, 88, 95, 112, 118, 119, 154, 191,//
+//          192, 194, 195, 206, 207                                            //
+// Status : Working -- Blaarg IRQ timing test fails, but may be submapper      //
+// Notes  : While currently working well, this mapper could use a full review. //
+// Games  : Crystalis, Battletoads                                             //
+//*****************************************************************************//
+wire mmc3_en = me[118] | me[119] | me[47] | me[206] | me[112] | me[88] | me[154] | me[95]
+	| me[76] | me[80] | me[82] | me[207] | me[48] | me[33] | me[37] | me[74] | me[191]
+	| me[192] | me[194] | me[195] | me[4];
 
-wire mmc5_prg_allow, mmc5_vram_a10, mmc5_vram_ce, mmc5_chr_allow, mmc5_irq;
-wire [21:0] mmc5_prg_addr, mmc5_chr_addr;
-wire [7:0] mmc5_chr_dout, mmc5_prg_dout;
-wire mmc5_has_chr_dout;
-wire [15:0] mmc5_audio;
-MMC5 mmc5(clk, ce, ppu_ce, reset, flags, ppuflags, prg_ain, mmc5_prg_addr, prg_read, prg_write, prg_din, mmc5_prg_dout, mmc5_prg_allow,
-	chr_read, chr_write, chr_din, chr_ain, mmc5_chr_addr, mmc5_chr_dout, mmc5_has_chr_dout, mmc5_chr_allow, mmc5_vram_a10,
-	mmc5_vram_ce, mmc5_irq, mmc5_audio);
+MMC3 mmc3 (
+	.clk        (clk),
+	.ce         (ppu_ce),
+	.enable     (mmc3_en),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map13_prg_allow, map13_vram_a10, map13_vram_ce, map13_chr_allow;
-wire [21:0] map13_prg_addr, map13_chr_addr;
-Mapper13 map13(clk, ce, reset, flags, prg_ain, map13_prg_addr, prg_read, prg_write, prg_din, map13_prg_allow,
-	chr_ain, map13_chr_addr, map13_chr_allow, map13_vram_a10, map13_vram_ce);
+//*****************************************************************************//
+// Name   : MMC4                                                               //
+// Mappers: 10                                                                 //
+// Status : Working                                                            //
+// Notes  :                                                                    //
+// Games  : Fire Emblem                                                        //
+//*****************************************************************************//
+MMC4 mmc4(
+	.clk        (clk),
+	.ce         (ppu_ce),
+	.enable     (me[10]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map15_prg_allow, map15_vram_a10, map15_vram_ce, map15_chr_allow;
-wire [21:0] map15_prg_addr, map15_chr_addr;
-Mapper15 map15(clk, ce, reset, flags, prg_ain, map15_prg_addr, prg_read, prg_write, prg_din, map15_prg_allow,
-	chr_ain, map15_chr_addr, map15_chr_allow, map15_vram_a10, map15_vram_ce);
+//*****************************************************************************//
+// Name   : MMC5                                                               //
+// Mappers: 5                                                                  //
+// Status : Fairly complete, but has some bugs. Check Rockman Minus Infinity.  //
+// Notes  : Uses expansion audio and PPU hacks. Could use a thorough review.   //
+// Games  : Castlevania III, Just Breed                                        //
+//*****************************************************************************//
+MMC5 mmc5(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[5]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b),
+	// Special ports
+	.chr_din    (chr_din),
+	.chr_write  (chr_write),
+	.chr_dout_b (chr_dout_b),
+	.ppu_ce     (ppu_ce),
+	.ppuflags   (ppuflags)
+);
 
-wire map16_prg_allow, map16_vram_a10, map16_vram_ce, map16_chr_allow, map16_irq, map16_prg_write, map16_ovr;
-wire [21:0] map16_prg_addr, map16_chr_addr;
-wire [7:0] map16_prg_dout, map16_data_out;
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper13 map13(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[13]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
+
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper15 map15(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[15]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
+
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+wire map16_prg_write, map16_ovr;
+wire [7:0] map16_data_out;
 wire [14:0] map16_mapper_addr;
-Mapper16 map16(clk, ce, reset, flags, prg_ain, map16_prg_addr, prg_read, prg_write, prg_din, map16_prg_dout, map16_prg_allow,
-	chr_ain, map16_chr_addr, map16_chr_allow, map16_vram_a10, map16_vram_ce, map16_mapper_addr, mapper_data_in,
-	map16_data_out, map16_prg_write, map16_ovr, map16_irq);
+Mapper16 map16(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[159] | me[16]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b),
+	// Special Ports
+	.mapper_addr(map16_mapper_addr),
+	.mapper_data_in(mapper_data_in),
+	.mapper_data_out(map16_data_out),
+	.mapper_prg_write(map16_prg_write),
+	.mapper_ovr(map16_ovr)
+);
 
-wire map18_prg_allow, map18_vram_a10, map18_vram_ce, map18_chr_allow, map18_irq;
-wire [21:0] map18_prg_addr, map18_chr_addr;
-wire [7:0] map18_prg_dout;
-Mapper18 map18(clk, ce, reset, flags, prg_ain, map18_prg_addr, prg_read, prg_write, prg_din, map18_prg_dout, map18_prg_allow,
-	chr_ain, map18_chr_addr, map18_chr_allow, map18_vram_a10, map18_vram_ce, map18_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper18 map18(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[18]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map34_prg_allow, map34_vram_a10, map34_vram_ce, map34_chr_allow;
-wire [21:0] map34_prg_addr, map34_chr_addr;
-Mapper34 map34(clk, ce, reset, flags, prg_ain, map34_prg_addr, prg_read, prg_write, prg_din, map34_prg_allow,
-	chr_ain, map34_chr_addr, map34_chr_allow, map34_vram_a10, map34_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper34 map34(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[34]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map41_prg_allow, map41_vram_a10, map41_vram_ce, map41_chr_allow;
-wire [21:0] map41_prg_addr, map41_chr_addr;
-Mapper41 map41(clk, ce, reset, flags, prg_ain, map41_prg_addr, prg_read, prg_write, prg_din, map41_prg_allow,
-	chr_ain, map41_chr_addr, map41_chr_allow, map41_vram_a10, map41_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper41 map41(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[41]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map42_prg_allow, map42_vram_a10, map42_vram_ce, map42_chr_allow, map42_irq;
-wire [21:0] map42_prg_addr, map42_chr_addr;
-Mapper42 map42(clk, ce, reset, flags, prg_ain, map42_prg_addr, prg_read, prg_write, prg_din, map42_prg_allow,
-	chr_ain, map42_chr_addr, map42_chr_allow, map42_vram_a10, map42_vram_ce, map42_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper42 map42(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[42]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map65_prg_allow, map65_vram_a10, map65_vram_ce, map65_chr_allow, map65_irq;
-wire [21:0] map65_prg_addr, map65_chr_addr;
-Mapper65 map65(clk, ce, reset, flags, prg_ain, map65_prg_addr, prg_read, prg_write, prg_din, map65_prg_allow,
-	chr_ain, map65_chr_addr, map65_chr_allow, map65_vram_a10, map65_vram_ce, map65_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper65 map65(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[65]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map66_prg_allow, map66_vram_a10, map66_vram_ce, map66_chr_allow;
-wire [21:0] map66_prg_addr, map66_chr_addr;
-Mapper66 map66(clk, ce, reset, flags, prg_ain, map66_prg_addr, prg_read, prg_write, prg_din, map66_prg_allow,
-	chr_ain, map66_chr_addr, map66_chr_allow, map66_vram_a10, map66_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+wire mapper66_en = me[11] | me[38] | me[86] | me[87] | me[101] | me[140] | me[66];
+Mapper66 map66(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (mapper66_en),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map67_prg_allow, map67_vram_a10, map67_vram_ce, map67_chr_allow, map67_irq;
-wire [21:0] map67_prg_addr, map67_chr_addr;
-Mapper67 map67(clk, ce, reset, flags, prg_ain, map67_prg_addr, prg_read, prg_write, prg_din, map67_prg_allow,
-	chr_ain, map67_chr_addr, map67_chr_allow, map67_vram_a10, map67_vram_ce, map67_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper67 map67(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[67] | me[190]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map68_prg_allow, map68_vram_a10, map68_vram_ce, map68_chr_allow;
-wire [21:0] map68_prg_addr, map68_chr_addr;
-Mapper68 map68(clk, ce, reset, flags, prg_ain, map68_prg_addr, prg_read, prg_write, prg_din, map68_prg_allow,
-	chr_ain, map68_chr_addr, map68_chr_allow, map68_vram_a10, map68_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper68 map68(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[68]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map69_prg_allow, map69_vram_a10, map69_vram_ce, map69_chr_allow, map69_irq;
-wire [21:0] map69_prg_addr, map69_chr_addr;
-wire [15:0] map69_audio;
-Mapper69 map69(clk, ce, reset, flags, prg_ain, map69_prg_addr, prg_read, prg_write, prg_din, map69_prg_allow,
-	chr_ain, map69_chr_addr, map69_chr_allow, map69_vram_a10, map69_vram_ce, map69_irq, map69_audio);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper69 map69(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[69]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map71_prg_allow, map71_vram_a10, map71_vram_ce, map71_chr_allow;
-wire [21:0] map71_prg_addr, map71_chr_addr;
-Mapper71 map71(clk, ce, reset, flags, prg_ain, map71_prg_addr, prg_read, prg_write, prg_din, map71_prg_allow,
-	chr_ain, map71_chr_addr, map71_chr_allow, map71_vram_a10, map71_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper71 map71(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[71] | me[232]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map72_prg_allow, map72_vram_a10, map72_vram_ce, map72_chr_allow;
-wire [21:0] map72_prg_addr, map72_chr_addr;
-Mapper72 map72(clk, ce, reset, flags, prg_ain, map72_prg_addr, prg_read, prg_write, prg_din, map72_prg_allow,
-	chr_ain, map72_chr_addr, map72_chr_allow, map72_vram_a10, map72_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper72 map72(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[92] | me[72]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map77_prg_allow, map77_vram_a10, map77_vram_ce, map77_chr_allow;
-wire [21:0] map77_prg_addr, map77_chr_addr;
-Mapper77 map77(clk, ce, reset, flags, prg_ain, map77_prg_addr, prg_read, prg_write, prg_din, map77_prg_allow,
-	chr_ain, map77_chr_addr, map77_chr_allow, map77_vram_a10, map77_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper77 map77(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[77]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map78_prg_allow, map78_vram_a10, map78_vram_ce, map78_chr_allow;
-wire [21:0] map78_prg_addr, map78_chr_addr;
-Mapper78 map78(clk, ce, reset, flags, prg_ain, map78_prg_addr, prg_read, prg_write, prg_din, map78_prg_allow,
-	chr_ain, map78_chr_addr, map78_chr_allow, map78_vram_a10, map78_vram_ce);
+//*****************************************************************************//
+// Name   : Holy Diver                                                         //
+// Mappers: 78, 70, 152                                                        //
+// Status : /Needs testing overall                                             //
+// Notes  : Submapper 1 Requires NES 2.0                                       //
+// Games  : Holy Diver, Uchuusent                                              //
+//*****************************************************************************//
+Mapper78 map78(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[152] | me[70] | me[78]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map79_prg_allow, map79_vram_a10, map79_vram_ce, map79_chr_allow;
-wire [21:0] map79_prg_addr, map79_chr_addr;
-Mapper79 map79(clk, ce, reset, flags, prg_ain, map79_prg_addr, prg_read, prg_write, prg_din, map79_prg_allow,
-	chr_ain, map79_chr_addr, map79_chr_allow, map79_vram_a10, map79_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper79 map79(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[79] | me[113]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map89_prg_allow, map89_vram_a10, map89_vram_ce, map89_chr_allow;
-wire [21:0] map89_prg_addr, map89_chr_addr;
-Mapper89 map89(clk, ce, reset, flags, prg_ain, map89_prg_addr, prg_read, prg_write, prg_din, map89_prg_allow,
-	chr_ain, map89_chr_addr, map89_chr_allow, map89_vram_a10, map89_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper89 map89(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[89] | me[93] | me[184]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map107_prg_allow, map107_vram_a10, map107_vram_ce, map107_chr_allow;
-wire [21:0] map107_prg_addr, map107_chr_addr;
-Mapper107 map107(clk, ce, reset, flags, prg_ain, map107_prg_addr, prg_read, prg_write, prg_din, map107_prg_allow,
-	chr_ain, map107_chr_addr, map107_chr_allow, map107_vram_a10, map107_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper107 map107(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[107]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map165_prg_allow, map165_vram_a10, map165_vram_ce, map165_chr_allow, map165_irq;
-wire [21:0] map165_prg_addr, map165_chr_addr;
-Mapper165 map165(clk, ppu_ce, reset, flags, prg_ain, map165_prg_addr, prg_read, prg_write, prg_din, map165_prg_allow,
-	chr_read, chr_ain, map165_chr_addr, map165_chr_allow, map165_vram_a10, map165_vram_ce, map165_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper165 map165(
+	.clk        (clk),
+	.ce         (ppu_ce),
+	.enable     (me[165]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map218_prg_allow, map218_vram_a10, map218_vram_ce, map218_chr_allow;
-wire [21:0] map218_prg_addr, map218_chr_addr;
-Mapper218 map218(clk, ce, reset, flags, prg_ain, map218_prg_addr, prg_read, prg_write, prg_din, map218_prg_allow,
-	chr_ain, map218_chr_addr, map218_chr_allow, map218_vram_a10, map218_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper218 map218(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[218]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map228_prg_allow, map228_vram_a10, map228_vram_ce, map228_chr_allow;
-wire [21:0] map228_prg_addr, map228_chr_addr;
-Mapper228 map228(clk, ce, reset, flags, prg_ain, map228_prg_addr, prg_read, prg_write, prg_din, map228_prg_allow,
-	chr_ain, map228_chr_addr, map228_chr_allow, map228_vram_a10, map228_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper228 map228(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[228]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Mapper234 map234(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[234]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map234_prg_allow, map234_vram_a10, map234_vram_ce, map234_chr_allow;
-wire [21:0] map234_prg_addr, map234_chr_addr;
-Mapper234 map234(clk, ce, reset, flags, prg_ain, map234_prg_addr, prg_read, prg_write, prg_from_ram, map234_prg_allow,
-	chr_ain, map234_chr_addr, map234_chr_allow, map234_vram_a10, map234_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+Rambo1 rambo1(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[64] | me[158]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire rambo1_prg_allow, rambo1_vram_a10, rambo1_vram_ce, rambo1_chr_allow, rambo1_irq;
-wire [21:0] rambo1_prg_addr, rambo1_chr_addr;
-Rambo1 rambo1(clk, ce, reset, flags, prg_ain, rambo1_prg_addr, prg_read, prg_write, prg_din, rambo1_prg_allow,
-	chr_ain, rambo1_chr_addr, rambo1_chr_allow, rambo1_vram_a10, rambo1_vram_ce, rambo1_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+NesEvent nesev(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[105]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);	
+	
 
-wire [21:0] nesev_prg_addr, nesev_chr_addr;
-wire nesev_irq;
-NesEvent nesev(clk, ce, reset, prg_ain, nesev_prg_addr, chr_ain, nesev_chr_addr, mmc1_chr_addr[16:13], mmc1_prg_addr, nesev_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+VRC1 vrc1(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[75]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire vrc1_prg_allow, vrc1_vram_a10, vrc1_vram_ce, vrc1_chr_allow;
-wire [21:0] vrc1_prg_addr, vrc1_chr_addr;
-VRC1 vrc1(clk, ce, reset, flags, prg_ain, vrc1_prg_addr, prg_read, prg_write, prg_din, vrc1_prg_allow,
-	chr_ain, vrc1_chr_addr, vrc1_chr_allow, vrc1_vram_a10, vrc1_vram_ce);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+VRC3 vrc3(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[73]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire vrc3_prg_allow, vrc3_vram_a10, vrc3_vram_ce, vrc3_chr_allow, vrc3_irq;
-wire [21:0] vrc3_prg_addr, vrc3_chr_addr;
-VRC3 vrc3(clk, ce, reset, flags, prg_ain, vrc3_prg_addr, prg_read, prg_write, prg_din, vrc3_prg_allow,
-	chr_ain, vrc3_chr_addr, vrc3_chr_allow, vrc3_vram_a10, vrc3_vram_ce, vrc3_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+VRC24 vrc24(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[21] | me[22] | me[23] | me[25]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire vrc24_prg_allow, vrc24_vram_a10, vrc24_vram_ce, vrc24_chr_allow, vrc24_irq;
-wire [21:0] vrc24_prg_addr, vrc24_chr_addr;
-VRC24 vrc24(clk, ce, reset, flags, prg_ain, vrc24_prg_addr, prg_read, prg_write, prg_din, vrc24_prg_allow,
-	chr_ain, vrc24_chr_addr, vrc24_chr_allow, vrc24_vram_a10, vrc24_vram_ce, vrc24_irq);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+VRC6 vrc6(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[24] | me[26]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire vrc6_prg_allow, vrc6_vram_a10, vrc6_vram_ce, vrc6_chr_allow, vrc6_irq;
-wire [21:0] vrc6_prg_addr, vrc6_chr_addr;
-wire [15:0] vrc6_audio;
-wire [7:0] vrc6_prg_dout;
-VRC6 vrc6(clk, ce, reset, flags, prg_ain, vrc6_prg_addr, prg_read, prg_write, prg_din, vrc6_prg_dout, vrc6_prg_allow,
-	chr_ain, vrc6_chr_addr, vrc6_chr_allow, vrc6_vram_a10, vrc6_vram_ce, vrc6_irq, vrc6_audio);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+VRC7 vrc7(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[85]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire vrc7_prg_allow, vrc7_vram_a10, vrc7_vram_ce, vrc7_chr_allow, vrc7_irq;
-wire [21:0] vrc7_prg_addr, vrc7_chr_addr;
-wire [15:0] vrc7_audio;
-VRC7 vrc7(clk, ce, reset, flags, prg_ain, vrc7_prg_addr, prg_read, prg_write, prg_din, vrc7_prg_allow,
-	chr_ain, vrc7_chr_addr, vrc7_chr_allow, vrc7_vram_a10, vrc7_vram_ce, vrc7_irq, vrc7_audio);
+//*****************************************************************************//
+// Name   :                                                                    //
+// Mappers:                                                                    //
+// Status :                                                                    //
+// Notes  :                                                                    //
+// Games  :                                                                    //
+//*****************************************************************************//
+N106 n106(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[210] | me[19]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
 
-wire map19_prg_allow, map19_vram_a10, map19_vram_ce, map19_chr_allow, map19_irq;
-wire [21:0] map19_prg_addr, map19_chr_addr;
-wire [15:0] map19_audio;
-wire [7:0] map19_prg_dout;
-N106 n106(clk, ce, reset, flags, prg_ain, map19_prg_addr, prg_read, prg_write, prg_din, map19_prg_dout, map19_prg_allow,
-	chr_ain, map19_chr_addr, map19_chr_allow, map19_vram_a10, map19_vram_ce, map19_irq, map19_audio);
-
-wire mapfds_prg_allow, mapfds_vram_a10, mapfds_vram_ce, mapfds_chr_allow, mapfds_irq;
-wire [21:0] mapfds_prg_addr, mapfds_chr_addr;
-wire [15:0] mapfds_audio;
-wire [7:0] mapfds_chr_dout, mapfds_prg_dout;
-MapperFDS mapfds(clk, ce, reset, flags, prg_ain, mapfds_prg_addr, prg_read, prg_write, prg_din, mapfds_prg_dout, mapfds_prg_allow,
-	chr_ain, mapfds_chr_addr, mapfds_chr_allow, mapfds_vram_a10, mapfds_vram_ce, mapfds_irq, mapfds_audio, fds_swap);
+//*****************************************************************************//
+// Name   : FDS                                                                //
+// Mappers: 20                                                                 //
+// Status : Audio good. Drive mechanics okay, but dated. Needs rewrite.        //
+// Notes  : Uses a special wire to signal disk changes. Req. modified BIOS.    //
+// Games  : Bio Miracle for audio, Various unlicensed games for compatibility. //
+//*****************************************************************************//
+MapperFDS mapfds(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[20]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b),
+	// Special ports
+	.fds_swap   (fds_swap)
+);
 
 // Mask
 reg [5:0] prg_mask;
 reg [6:0] chr_mask;
+
+
+
+reg [255:0] me = 0;
+
+always @(posedge clk) begin
+	me <= 255'd0;
+	me[flags[7:0]] <= 1'b1;
+end
 
 always @* begin
 	case(flags[10:8])
@@ -286,136 +1344,15 @@ always @* begin
 		7: chr_mask = 7'b1111111;
 	endcase
 
-	irq = 0;
-	prg_dout = 8'hff;
-	has_chr_dout = 0;
-	chr_dout = mmc5_chr_dout;
-	audio = 16'h0000;
-	mapper_addr = 14'h0000;
-	mapper_data_out = 8'h00;
-	mapper_prg_write = 1'b0;
-	mapper_ovr = 1'b0;
-	prg_open_bus = map28_open_bus; // Expand to other mappers?
-	prg_conflict = map28_conflict; // Expand to other mappers?
+	{prg_conflict, prg_open_bus, has_chr_dout} = {flags_out_b[2], flags_out_b[1], flags_out_b[0]};
+	chr_dout = flags_out_b[0] ? chr_dout_b : 8'hFF;
 
-	case(flags[7:0])
-	155,
-	1:  {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {mmc1_prg_addr, mmc1_prg_allow, mmc1_chr_addr, mmc1_vram_a10, mmc1_vram_ce, mmc1_chr_allow};
-	9:  {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {mmc2_prg_addr, mmc2_prg_allow, mmc2_chr_addr, mmc2_vram_a10, mmc2_vram_ce, mmc2_chr_allow};
-	118, // TxSROM connects A17 to CIRAM A10.
-	119, // TQROM  uses the Nintendo MMC3 like other TxROM boards but uses the CHR bank number specially.
-	47,  // Mapper 047 is a MMC3 multicart
-	206, // MMC3 w/o IRQ or WRAM support
-	112, // Like 206 with different layout
-	88,  // NAMCOT-3433 is mapper 206-like, but connects PPU-A12 to CHROM A16.
-	154, // NAMCOT-3453 is mapper 88-like, but with one screen mirroring.
-	95,  // NAMCOT-3425 is mapper 206-like, but connects A16 to CIRAM A10.
-	76,  // NAMCOT-3446 is mapper 206-like, but coarser chr banking.
-	80,  // Taito X01-005 is MMC3-like with Internal RAM and no IRQ
-	82,  // Tatio X01-017 is mapper 80-like with more Internal RAM
-	207, // Tatio X01-005 is mapper 80-like with one screen mirroring
-	48,  // MMC3-like with delayed IRQ
-	33,  // Mapper 48 without IRQ and different mirroring location
-	37,  // European Triple Cart (Super Mario, Tetris, Nintendo World Cup)
-	74,  // MMC3 like but uses the CHR RAM.
-	191, // MMC3 like but uses the CHR RAM.
-	192, // MMC3 like but uses the CHR RAM.
-	194, // MMC3 like but uses the CHR RAM.
-	195, // MMC3 like but uses the CHR RAM.
-	4:  {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {mmc3_prg_addr, mmc3_prg_allow, mmc3_chr_addr, mmc3_vram_a10, mmc3_vram_ce, mmc3_chr_allow, mmc3_irq};
+	// Currently only used for Mapper 16 EEPROM. Expand if needed.
+	{mapper_addr, mapper_data_out, mapper_prg_write, mapper_ovr} = (me[159] | me[16]) ?
+		{map16_mapper_addr, map16_data_out, map16_prg_write, map16_ovr} : 25'd0;
 
-	10: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {mmc4_prg_addr, mmc4_prg_allow, mmc4_chr_addr, mmc4_vram_a10, mmc4_vram_ce, mmc4_chr_allow};
-
-	5:  {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, has_chr_dout, prg_dout, irq, audio} = {mmc5_prg_addr, mmc5_prg_allow, mmc5_chr_addr, mmc5_vram_a10, mmc5_vram_ce, mmc5_chr_allow, mmc5_has_chr_dout, mmc5_prg_dout, mmc5_irq, mmc5_audio};
-
-	0,
-	2,
-	3,
-	7,
-	94,
-	97,
-	180,
-	185,
-	28: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, chr_dout, has_chr_dout}      = {map28_prg_addr, map28_prg_allow, map28_chr_addr, map28_vram_a10, map28_vram_ce, map28_chr_allow, map28_chr_dout, map28_has_chr_dout};
-
-	89,
-	93,
-	184: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map89_prg_addr, map89_prg_allow, map89_chr_addr, map89_vram_a10, map89_vram_ce, map89_chr_allow};
-
-	30: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map30_prg_addr, map30_prg_allow, map30_chr_addr, map30_vram_a10, map30_vram_ce, map30_chr_allow};
-
-	32: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map32_prg_addr, map32_prg_allow, map32_chr_addr, map32_vram_a10, map32_vram_ce, map32_chr_allow};
-
-	13: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map13_prg_addr, map13_prg_allow, map13_chr_addr, map13_vram_a10, map13_vram_ce, map13_chr_allow};
-	15: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map15_prg_addr, map15_prg_allow, map15_chr_addr, map15_vram_a10, map15_vram_ce, map15_chr_allow};
-
-	159,
-	16: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, prg_dout, mapper_addr, mapper_data_out, mapper_prg_write, mapper_ovr, irq}
-	= {map16_prg_addr, map16_prg_allow, map16_chr_addr, map16_vram_a10, map16_vram_ce, map16_chr_allow, map16_prg_dout, map16_mapper_addr, map16_data_out, map16_prg_write, map16_ovr, map16_irq};
-
-	18: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, prg_dout, irq} = {map18_prg_addr, map18_prg_allow, map18_chr_addr, map18_vram_a10, map18_vram_ce, map18_chr_allow, map18_prg_dout, map18_irq};
-
-	34: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map34_prg_addr, map34_prg_allow, map34_chr_addr, map34_vram_a10, map34_vram_ce, map34_chr_allow};
-	41: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map41_prg_addr, map41_prg_allow, map41_chr_addr, map41_vram_a10, map41_vram_ce, map41_chr_allow};
-
-	64,
-	158: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {rambo1_prg_addr, rambo1_prg_allow, rambo1_chr_addr, rambo1_vram_a10, rambo1_vram_ce, rambo1_chr_allow, rambo1_irq};
-
-	42: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {map42_prg_addr, map42_prg_allow, map42_chr_addr, map42_vram_a10, map42_vram_ce, map42_chr_allow, map42_irq};
-
-	65: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {map65_prg_addr, map65_prg_allow, map65_chr_addr, map65_vram_a10, map65_vram_ce, map65_chr_allow, map65_irq};
-	190,
-	67: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {map67_prg_addr, map67_prg_allow, map67_chr_addr, map67_vram_a10, map67_vram_ce, map67_chr_allow, map67_irq};
-
-	11,
-	38,
-	86,
-	87,
-	101,
-	140,
-	66: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map66_prg_addr, map66_prg_allow, map66_chr_addr, map66_vram_a10, map66_vram_ce, map66_chr_allow};
-	68: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map68_prg_addr, map68_prg_allow, map68_chr_addr, map68_vram_a10, map68_vram_ce, map68_chr_allow};
-	69: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq, audio} = {map69_prg_addr, map69_prg_allow, map69_chr_addr, map69_vram_a10, map69_vram_ce, map69_chr_allow, map69_irq, map69_audio};
-
-	71,
-	232: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}     = {map71_prg_addr, map71_prg_allow, map71_chr_addr, map71_vram_a10, map71_vram_ce, map71_chr_allow};
-
-	92,
-	72: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map72_prg_addr, map72_prg_allow, map72_chr_addr, map72_vram_a10, map72_vram_ce, map72_chr_allow};
-
-	77: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map77_prg_addr, map77_prg_allow, map77_chr_addr, map77_vram_a10, map77_vram_ce, map77_chr_allow};
-
-	152,
-	70,
-	78: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}     = {map78_prg_addr, map78_prg_allow, map78_chr_addr, map78_vram_a10, map78_vram_ce, map78_chr_allow};
-
-	79,
-	113: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}     = {map79_prg_addr, map79_prg_allow, map79_chr_addr, map79_vram_a10, map79_vram_ce, map79_chr_allow};
-
-	105: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq}= {nesev_prg_addr, mmc1_prg_allow, nesev_chr_addr, mmc1_vram_a10, mmc1_vram_ce, mmc1_chr_allow, nesev_irq};
-
-	107: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map107_prg_addr, map107_prg_allow, map107_chr_addr, map107_vram_a10, map107_vram_ce, map107_chr_allow};
-
-	165: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {map165_prg_addr, map165_prg_allow, map165_chr_addr, map165_vram_a10, map165_vram_ce, map165_chr_allow, map165_irq};
-
-	218: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {map218_prg_addr, map218_prg_allow, map218_chr_addr, map218_vram_a10, map218_vram_ce, map218_chr_allow};
-
-	228: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}     = {map228_prg_addr, map228_prg_allow, map228_chr_addr, map228_vram_a10, map228_vram_ce, map228_chr_allow};
-	234: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}     = {map234_prg_addr, map234_prg_allow, map234_chr_addr, map234_vram_a10, map234_vram_ce, map234_chr_allow};
-	75: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow}      = {vrc1_prg_addr, vrc1_prg_allow, vrc1_chr_addr, vrc1_vram_a10, vrc1_vram_ce, vrc1_chr_allow};
-	20: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, prg_dout, irq, audio} = {mapfds_prg_addr, mapfds_prg_allow, mapfds_chr_addr, mapfds_vram_a10, mapfds_vram_ce, mapfds_chr_allow, mapfds_prg_dout, mapfds_irq, mapfds_audio};
-	21,
-	22,
-	23,
-	25: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {vrc24_prg_addr, vrc24_prg_allow, vrc24_chr_addr, vrc24_vram_a10, vrc24_vram_ce, vrc24_chr_allow, vrc24_irq};
-	73: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq} = {vrc3_prg_addr, vrc3_prg_allow, vrc3_chr_addr, vrc3_vram_a10, vrc3_vram_ce, vrc3_chr_allow, vrc3_irq};
-	24,
-	26: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, prg_dout, irq, audio} = {vrc6_prg_addr, vrc6_prg_allow, vrc6_chr_addr, vrc6_vram_a10, vrc6_vram_ce, vrc6_chr_allow, vrc6_prg_dout, vrc6_irq, vrc6_audio};
-	85: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, irq, audio} = {vrc7_prg_addr, vrc7_prg_allow, vrc7_chr_addr, vrc7_vram_a10, vrc7_vram_ce, vrc7_chr_allow, vrc7_irq, vrc7_audio};
-	210,
-	19: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow, prg_dout, irq, audio} = {map19_prg_addr, map19_prg_allow, map19_chr_addr, map19_vram_a10, map19_vram_ce, map19_chr_allow, map19_prg_dout, map19_irq, map19_audio};
-	default: {prg_aout, prg_allow, chr_aout, vram_a10, vram_ce, chr_allow} = {mmc0_prg_addr, mmc0_prg_allow, mmc0_chr_addr, mmc0_vram_a10, mmc0_vram_ce, mmc0_chr_allow};
-	endcase
+	{prg_aout,   prg_allow,   chr_aout,   vram_a10,   vram_ce,   chr_allow,   prg_dout,   irq,   audio} = 
+	{prg_addr_b, prg_allow_b, chr_addr_b, vram_a10_b, vram_ce_b, chr_allow_b, prg_dout_b, irq_b, audio_out_b};
 
 	if (prg_aout[21:20] == 2'b00)
 		prg_aout[19:0] = {prg_aout[19:14] & prg_mask, prg_aout[13:0]};
@@ -431,23 +1368,10 @@ end
 
 endmodule
 
-// PRG       = 0....
-// CHR       = 10...
-// CHR-VRAM  = 1100
-// CPU-RAM   = 1110
-// CARTRAM   = 1111
 
 
 
-// 0 = Working
-// 1 = Working
-// 2 = Working
-// 3 = Working
-// 4 = Working
-// 5 = Working/Audio needs testing/Some games graphics corruption (Just Breed)
-// 7 = Working
-// 9 = Working
-// 10 = Working
+
 // 11 = Working
 // 13 = Working
 // 15 = Working
@@ -463,7 +1387,6 @@ endmodule
 // 26 = Needs testing
 // 28 = Working
 // 30 = No Self Flashing/Needs testing
-// 32 = Needs testing
 // 33 = Needs testing
 // 34 = Working
 // 37 = Needs testing
@@ -486,7 +1409,7 @@ endmodule
 // 75 = Needs testing
 // 76 = Needs testing
 // 77 = Needs testing
-// 78 = Submapper 1 Requires NES 2.0/Needs testing overall
+// 78 = 
 // 79 = Working
 // 80 = Needs testing
 // 82 = Needs testing
@@ -505,7 +1428,6 @@ endmodule
 // 107 = Needs testing
 // 112 = Needs testing
 // 113 = Working
-// 118 = Working
 // 119 = Working
 // 140 = Needs testing
 // 152 = Needs testing

--- a/mappers/FDS.sv
+++ b/mappers/FDS.sv
@@ -1,18 +1,52 @@
 //Famicom Disk System
 
-module MapperFDS(input clk, input ce, input reset,
-                 input [31:0] flags,
-                 input [15:0] prg_ain, output [21:0] prg_aout,
-                 input prg_read, prg_write,                   // Read / write signals
-                 input [7:0] prg_din, output [7:0] prg_dout,
-                 output prg_allow,                          // Enable access to memory for the specified operation.
-                 input [13:0] chr_ain, output [21:0] chr_aout,
-                 output chr_allow,                             // Allow write
-                 output vram_a10,                              // Value for A10 address line
-                 output vram_ce,                               // True if the address should be routed to the internal 2kB VRAM.
-                 output irq,
-                 output [15:0] audio,
-					  input fds_swap);
+module MapperFDS(
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b, // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
+	// Special ports
+	input        fds_swap     // User input to change disks
+);
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? prg_dout : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire [7:0] prg_dout;
+reg [15:0] flags_out = 0;
+wire irq;
+wire [15:0] audio;
+
 	 wire nesprg_oe;
     wire [7:0] neschrdout;
 	 wire neschr_oe;
@@ -36,26 +70,26 @@ module MapperFDS(input clk, input ce, input reset,
 //    output prgram_oe, output [18:10] ramchraout, output [18:13] ramprgaout, output irq, output ciram_ce, output exp6,
 //    input cfg_boot, input [18:12] cfg_chrmask, input [18:13] cfg_prgmask, input cfg_vertical, input cfg_fourscreen, input cfg_chrram,
 //    input ce, output prg_allow, output [11:0] snd_level);
-    MAPFDS fds(m2[7], m2_n, clk, reset, prg_write, nesprg_oe, 0, 
+    MAPFDS fds(m2[7], m2_n, clk, ~enable, prg_write, nesprg_oe, 0, 
 		1, prg_ain, chr_ain, prg_din, 8'b0, prg_dout,
 		neschrdout, neschr_oe, chr_allow, chrram_oe, wram_oe, wram_we, prgram_we,
 		prgram_oe, chr_aout[18:10], prg_aout[18:0], irq, vram_ce, exp6, 
 		0, 7'b1111111, 6'b111111, flags[14], flags[16], flags[15],
-		ce, fds_swap, prg_allow, audio_in);
+		ce, fds_swap, prg_allow, audio_exp);
     assign chr_aout[21:19] = 3'b100;
     assign chr_aout[9:0] = chr_ain[9:0];
     assign vram_a10 = chr_aout[10];
     assign prg_aout[21:19] = 3'b000;
     //assign prg_aout[12:0] = prg_ain[12:0];
 
-    wire [11:0] audio_in;
+    wire [11:0] audio_exp;
 
     // XXX: This needs to be replaced with a proper ~2000hz LPF
     lpf_aud fds_lpf
     (
       .CLK(clk),
       .CE(ce),
-      .IDATA({1'b0, audio_in, audio_in[2:0]}),
+      .IDATA({1'b0, audio_exp, audio_exp[2:0]}),
       .ODATA(audio)
     );
 

--- a/mappers/FDS.sv
+++ b/mappers/FDS.sv
@@ -47,51 +47,45 @@ reg [15:0] flags_out = 0;
 wire irq;
 wire [15:0] audio;
 
-	 wire nesprg_oe;
-    wire [7:0] neschrdout;
-	 wire neschr_oe;
-	 wire wram_oe;
-	 wire wram_we;
-	 wire prgram_we;
-	 wire chrram_oe;
-	 wire prgram_oe;
-	 wire exp6;
-	 reg [7:0] m2;
-	 wire m2_n = 1;//~ce;  //m2_n not used as clk.  Invert m2 (ce).
-  always @(posedge clk) begin
-    m2[7:1] <= m2[6:0];
-	 m2[0] <= ce;
-  end
-	 
-//module MAPFDS(              //signal descriptions in powerpak.v
-//    input m2, input m2_n, input clk20, input reset, input nesprg_we, output nesprg_oe, input neschr_rd,
-//    input neschr_wr, input [15:0] prgain, input [13:0] chrain, input [7:0] nesprgdin, input [7:0] ramprgdin, output reg [7:0] nesprgdout,
-//    output [7:0] neschrdout, output neschr_oe, output chrram_we, output chrram_oe, output wram_oe, output wram_we, output prgram_we,
-//    output prgram_oe, output [18:10] ramchraout, output [18:13] ramprgaout, output irq, output ciram_ce, output exp6,
-//    input cfg_boot, input [18:12] cfg_chrmask, input [18:13] cfg_prgmask, input cfg_vertical, input cfg_fourscreen, input cfg_chrram,
-//    input ce, output prg_allow, output [11:0] snd_level);
-    MAPFDS fds(m2[7], m2_n, clk, ~enable, prg_write, nesprg_oe, 0, 
+	wire nesprg_oe;
+		wire [7:0] neschrdout;
+	wire neschr_oe;
+	wire wram_oe;
+	wire wram_we;
+	wire prgram_we;
+	wire chrram_oe;
+	wire prgram_oe;
+	wire exp6;
+	reg [7:0] m2;
+	wire m2_n = 1;//~ce;  //m2_n not used as clk.  Invert m2 (ce).
+	always @(posedge clk) begin
+		m2[7:1] <= m2[6:0];
+	m2[0] <= ce;
+	end
+
+
+		MAPFDS fds(m2[7], m2_n, clk, ~enable, prg_write, nesprg_oe, 0,
 		1, prg_ain, chr_ain, prg_din, 8'b0, prg_dout,
 		neschrdout, neschr_oe, chr_allow, chrram_oe, wram_oe, wram_we, prgram_we,
-		prgram_oe, chr_aout[18:10], prg_aout[18:0], irq, vram_ce, exp6, 
+		prgram_oe, chr_aout[18:10], prg_aout[18:0], irq, vram_ce, exp6,
 		0, 7'b1111111, 6'b111111, flags[14], flags[16], flags[15],
 		ce, fds_swap, prg_allow, audio_exp);
-    assign chr_aout[21:19] = 3'b100;
-    assign chr_aout[9:0] = chr_ain[9:0];
-    assign vram_a10 = chr_aout[10];
-    assign prg_aout[21:19] = 3'b000;
-    //assign prg_aout[12:0] = prg_ain[12:0];
+		assign chr_aout[21:19] = 3'b100;
+		assign chr_aout[9:0] = chr_ain[9:0];
+		assign vram_a10 = chr_aout[10];
+		assign prg_aout[21:19] = 3'b000;
+		//assign prg_aout[12:0] = prg_ain[12:0];
 
-    wire [11:0] audio_exp;
+		wire [11:0] audio_exp;
 
-    // XXX: This needs to be replaced with a proper ~2000hz LPF
-    lpf_aud fds_lpf
-    (
-      .CLK(clk),
-      .CE(ce),
-      .IDATA({1'b0, audio_exp, audio_exp[2:0]}),
-      .ODATA(audio)
-    );
+		// XXX: This needs to be replaced with a proper ~2000hz LPF
+		lpf_aud fds_lpf
+		(
+			.CLK(clk),
+			.CE(ce),
+			.IDATA({1'b0, audio_exp, audio_exp[2:0]}),
+			.ODATA(audio)
+		);
 
 endmodule
 
@@ -129,20 +123,21 @@ module MAPFDS(              //signal descriptions in powerpak.v
 	output irq,
 	output ciram_ce,
 	output exp6,
-	
+
 	input cfg_boot,
 	input [18:12] cfg_chrmask,
 	input [18:13] cfg_prgmask,
 	input cfg_vertical,
 	input cfg_fourscreen,
 	input cfg_chrram,
-	
+
 	input ce,// add
 	input fds_swap,
 	output prg_allow,
 	output [11:0] snd_level,
 	input [1:0] diskside_manual
 );
+
 	localparam WRITE_LO=16'hF4CD, WRITE_HI=16'hF4CE, READ_LO=16'hF4D0, READ_HI=16'hF4D1;
 
 	assign neschrdout = 0;
@@ -171,11 +166,11 @@ module MAPFDS(              //signal descriptions in powerpak.v
 	reg [15:0] diskpos;
 	reg [17:0] sideoffset;
 	wire [17:0] romoffset;
-	
+
 //	Loopy's patched bios use a trick to catch requested diskside for games
 // using standard bios load process.
 // Unlicensed games sometimes doesn't use standard bios load process. This
-// break automatic diskside trick. 
+// break automatic diskside trick.
 // diskside_manual to be manage from OSD user input allow to add diskswap capabilities.
 // (automatic fds_swap should be preferably stopped before changing diskside_manual)
 
@@ -190,7 +185,7 @@ module MAPFDS(              //signal descriptions in powerpak.v
 		3:sideoffset=18'h2ffa4;
 	endcase
 	assign romoffset=diskpos + sideoffset;
-	
+
 // Unlicensed fds games use NMI trick to skip protection. Rationale is to load
 // a file starting @$2000 with $90 or $80 to enable NMI. This file should be at
 // least 256 bytes length to allow NMI to occure before end of load. PC is then
@@ -198,198 +193,210 @@ module MAPFDS(              //signal descriptions in powerpak.v
 // But with loopy's patched bios the 256 bytes file is loaded too fast and no NMI
 // occure early enough.
 // Here proposed solution is to create an infinite loop at the end of normal
-// load subroutine if @$2000 was written during load subroutine. Infinite loop 
+// load subroutine if @$2000 was written during load subroutine. Infinite loop
 // give enough time for NMI to occure. (Generaly observed NMI enabling file is
 // the last file of 'normal' loading process to be loaded).
-	
+
 	// manage infinite loop trap at the end ($E233) of LoadFiles subroutine
 //	 reg previous_is_E1F9;
 	reg infinite_loop_on_E233 = 0;
 	reg within_loader = 0;
 //	 reg loader_write_in_2000 = 0;
-	always@(posedge clk20)
-			if(reset) begin
-				// on reset activate infinite loop trap
-			end	
-			else begin 
-					if ((m2) && (ramprgaout[18]==1'b0))begin
-								
-						// detect enter / leave LoadFile subroutine
-						if(prgain==16'hE1FA) within_loader <= 1;
-						if(prgain==16'hE235) within_loader <= 0;
-						
-						// deactivate infinite loop at LoadFile subroutine
-						if(prgain==16'hE1FA) infinite_loop_on_E233 <= 0;
-						
-						// activate infinite loop if @$2000 is accessed during FileLoad subroutine
-						if((prgain==16'h2000) && (within_loader == 1)) infinite_loop_on_E233 <= 1;
-					end
-					
-			end 
-
-	//NES data out
-	wire match0=prgain==16'h4030;       //IRQ status
-	wire match1=prgain==16'h4032;       //drive status
-	wire match2=prgain==16'h4033;       //power / exp
-	wire match3=((prgain==READ_LO)|(prgain==WRITE_LO))&!(Wstate==2 | Rstate==2);
-	wire match4=((prgain==READ_HI)|(prgain==WRITE_HI))&!(Wstate==2 | Rstate==2);
-	wire match5=prgain==16'h4208;       //powerpak save flag
-	wire match6=prgain[15:8]==8'h40 && |prgain[7:6];    //4040..40FF
-	wire match7=(prgain==16'hE233) & infinite_loop_on_E233 & (ramprgaout[18]==1'b0);
-	wire match8=(prgain==16'hE234) & infinite_loop_on_E233 & (ramprgaout[18]==1'b0);
-	wire match9=(prgain==16'hE235) & infinite_loop_on_E233 & (ramprgaout[18]==1'b0);
-	always@*
-		case(1)
-			match0: nesprgdout={7'd0, timer_irq};
-			match1: nesprgdout={5'd0, disk_eject, diskend, disk_eject};
-			match2: nesprgdout=8'b10000000;
-			match3: nesprgdout=romoffset[7:0];
-			match4: nesprgdout={3'b111,romoffset[12:8]};
-			match5: nesprgdout={7'd0,saved};
-			match6: nesprgdout=audio_dout;
-			match7: nesprgdout=8'h4C;  // when infinite loop is active replace jsr $E778 with jmp $E233 
-			match8: nesprgdout=8'h33;
-			match9: nesprgdout=8'hE2;
-			default: nesprgdout=ramprgdin;
-		endcase
-	assign prg_allow = (nesprg_we & (Wstate==2 | (prgain[15]^(&prgain[14:13]))))
-					| (~nesprg_we & ((prgain[15] & !match3 & !match4 & !match7 & !match8 & !match9) | prgain[15:13]==3));
-
-    reg write_en;
-    reg vertical;
-    reg timer_irq_en;
-    reg timer_irq_repeat;
-    reg diskreset;
-    reg disk_reg_en;
-    reg [15:0] timerlatch;
-    reg [15:0] timer;
-    always@(posedge clk20) begin
-        if (ce) begin
-
-            if (timer_irq_en) begin
-                if (timer == 0) begin
-                    timer_irq <= 1;
-                    timer <= timerlatch;
-                    if (~timer_irq_repeat) begin
-                        timer_irq_en <= 0;
-                    end
-                end else begin
-                    timer <= timer - 1'd1;
-                end
-            end
-
-            if(nesprg_we)
-                case(prgain)
-                    16'h4020:
-                        timerlatch[7:0]<=nesprgdin;
-                    16'h4021:
-                        timerlatch[15:8]<=nesprgdin;
-                    16'h4022:
-                        begin
-                            timer_irq_repeat<=nesprgdin[0];
-                            timer_irq_en<=nesprgdin[1] & disk_reg_en;
-
-                            if (nesprgdin[1] & disk_reg_en) begin
-                                timer <= timerlatch;
-                            end else begin
-                                timer_irq <= 0;
-                            end
-                        end
-                    16'h4023: begin
-                            disk_reg_en <=nesprgdin[0];
-                            if (~nesprgdin[0]) begin
-                                timer_irq_en <= 0;
-                                timer_irq <= 0;
-                            end
-                        end
-                    //16'h4024: //disk data write
-                    16'h4025:   //disk control
-                        begin
-                            diskreset<=nesprgdin[1];
-                            write_en<=!nesprgdin[2];
-                            vertical<=!nesprgdin[3];
-                            //disk_irq_en<=nesprgdin[7];
-                        end
-                    16'h4027:   //powerpak extra: disk side
-                            diskside_auto<=nesprgdin[1:0];
-                endcase
-        end
-
-        if (m2) begin
-            if (~nesprg_we & prgain==16'h4030)
-                timer_irq <= 0;
-        end
-    end
-
-	//watch for disk read/write
-	always@(posedge clk20) begin
-		if (m2) begin
-		if(write_en & ~nesprg_we & (prgain==WRITE_LO))          Wstate<=1;
-		else if(~nesprg_we & (prgain==WRITE_HI) & Wstate==1)    Wstate<=2;
-		else                                                    Wstate<=0;
-
-		if(~nesprg_we & (prgain==READ_LO))                      Rstate<=1;
-		else if(~nesprg_we & (prgain==READ_HI) & Rstate==1)     Rstate<=2;
-		else                                                    Rstate<=0;
-
-		if(Wstate==2) saved<=1;
+always@(posedge clk20)
+		if(reset) begin
+			// on reset activate infinite loop trap
 		end
-	end
+		else begin
+				if ((m2) && (ramprgaout[18]==1'b0))begin
 
-	//disk pointer
-	always@(posedge clk20) begin
-		if (m2) begin
-		if(diskreset)                   diskpos<=0;
-		else if(Rstate==2 & !diskend)   diskpos<=diskpos+1'd1;
+					// detect enter / leave LoadFile subroutine
+					if(prgain==16'hE1FA) within_loader <= 1;
+					if(prgain==16'hE235) within_loader <= 0;
+
+					// deactivate infinite loop at LoadFile subroutine
+					if(prgain==16'hE1FA) infinite_loop_on_E233 <= 0;
+
+					// activate infinite loop if @$2000 is accessed during FileLoad subroutine
+					if((prgain==16'h2000) && (within_loader == 1)) infinite_loop_on_E233 <= 1;
+				end
+
 		end
-	end
 
-	assign irq=timer_irq; // | disk_irq
+//NES data out
+wire match0=prgain==16'h4030;       //IRQ status
+wire match1=prgain==16'h4032;       //drive status
+wire match2=prgain==16'h4033;       //power / exp
+wire match3=((prgain==READ_LO)|(prgain==WRITE_LO))&!(Wstate==2 | Rstate==2);
+wire match4=((prgain==READ_HI)|(prgain==WRITE_HI))&!(Wstate==2 | Rstate==2);
+wire match5=prgain==16'h4208;       //powerpak save flag
+wire match6=prgain[15:8]==8'h40 && |prgain[7:6];    //4040..40FF
+wire match7=(prgain==16'hE233) & infinite_loop_on_E233 & (ramprgaout[18]==1'b0);
+wire match8=(prgain==16'hE234) & infinite_loop_on_E233 & (ramprgaout[18]==1'b0);
+wire match9=(prgain==16'hE235) & infinite_loop_on_E233 & (ramprgaout[18]==1'b0);
+always@*
+	case(1)
+		match0: nesprgdout={7'd0, timer_irq};
+		match1: nesprgdout={5'd0, disk_eject, diskend, disk_eject};
+		match2: nesprgdout=8'b10000000;
+		match3: nesprgdout=romoffset[7:0];
+		match4: nesprgdout={3'b111,romoffset[12:8]};
+		match5: nesprgdout={7'd0,saved};
+		match6: nesprgdout=audio_dout;
+		match7: nesprgdout=8'h4C;  // when infinite loop is active replace jsr $E778 with jmp $E233
+		match8: nesprgdout=8'h33;
+		match9: nesprgdout=8'hE2;
+		default: nesprgdout=ramprgdin;
+	endcase
+assign prg_allow = (nesprg_we & (Wstate==2 | (prgain[15]^(&prgain[14:13]))))
+				| (~nesprg_we & ((prgain[15] & !match3 & !match4 & !match7 & !match8 & !match9) | prgain[15:13]==3));
 
-	//disk eject:   toggle flag continuously except when select button is held
-	reg [2:0] control_cnt;
-	reg [21:0] clkcount;
-	//reg button;
-	assign disk_eject=clkcount[21] | fds_swap;
+	reg write_en;
+	reg vertical;
+	reg timer_irq_en;
+	reg timer_irq_repeat;
+	reg diskreset;
+	reg disk_reg_en;
+	reg [15:0] timerlatch;
+	reg [15:0] timer;
 	always@(posedge clk20) begin
 		if (ce) begin
+			if (timer_irq_en) begin
+				if (timer == 0) begin
+					timer_irq <= 1;
+					timer <= timerlatch;
+					if (~timer_irq_repeat) begin
+						timer_irq_en <= 0;
+					end
+				end else begin
+					timer <= timer - 1'd1;
+				end
+		end
+
+		if(nesprg_we)
+			case(prgain)
+				16'h4020: timerlatch[7:0]<=nesprgdin;
+
+				16'h4021: timerlatch[15:8]<=nesprgdin;
+
+				16'h4022: begin
+					timer_irq_repeat<=nesprgdin[0];
+					timer_irq_en<=nesprgdin[1] & disk_reg_en;
+
+					if (nesprgdin[1] & disk_reg_en) begin
+						timer <= timerlatch;
+					end else begin
+						timer_irq <= 0;
+					end
+				end
+
+				16'h4023: begin
+					disk_reg_en <=nesprgdin[0];
+					if (~nesprgdin[0]) begin
+						timer_irq_en <= 0;
+						timer_irq <= 0;
+					end
+				end
+
+				//16'h4024: //disk data write
+				16'h4025: begin // disk control
+					diskreset<=nesprgdin[1];
+					write_en<=!nesprgdin[2];
+					vertical<=!nesprgdin[3];
+					//disk_irq_en<=nesprgdin[7];
+				end
+
+				16'h4027:   //powerpak extra: disk side
+					diskside_auto<=nesprgdin[1:0];
+			endcase
+	end
+
+	if (m2) begin
+		if (~nesprg_we & prgain==16'h4030)
+			timer_irq <= 0;
+	end
+end
+
+//watch for disk read/write
+always@(posedge clk20) begin
+	if (m2) begin
+		if(write_en & ~nesprg_we & (prgain==WRITE_LO))
+			Wstate<=1;
+		else if(~nesprg_we & (prgain==WRITE_HI) & Wstate==1)
+			Wstate<=2;
+		else 
+			Wstate<=0;
+
+		if(~nesprg_we & (prgain==READ_LO))
+			Rstate<=1;
+		else if(~nesprg_we & (prgain==READ_HI) & Rstate==1)
+			Rstate<=2;
+		else
+			Rstate<=0;
+
+		if(Wstate==2)
+			saved<=1;
+	end
+end
+
+//disk pointer
+always@(posedge clk20) begin
+	if (m2) begin
+		if(diskreset)
+			diskpos<=0;
+		else if(Rstate==2 & !diskend)
+			diskpos<=diskpos+1'd1;
+	end
+end
+
+assign irq=timer_irq; // | disk_irq
+
+//disk eject:   toggle flag continuously except when select button is held
+reg [2:0] control_cnt;
+reg [21:0] clkcount;
+
+assign disk_eject=clkcount[21] | fds_swap;
+
+always@(posedge clk20) begin
+	if (ce) begin
 		clkcount<=clkcount+1'd1;
 		if(prgain==16'h4016) begin
 			if(nesprg_we)                           control_cnt<=0;
 			else if(~nesprg_we & control_cnt!=7)    control_cnt<=control_cnt+1'd1;
 			//if(~nesprg_we & control_cnt==2)          button<=|nesprgdin[1:0];
 		end
-		end
 	end
+end
 
-	//bankswitch control: 6000-DFFF = sram, E000-FFFF = bios or disk
-	reg [18:13] prgbank;
-	wire [18:13] diskbank={1'b1,romoffset[17:13]};
-	always@* begin
-		if(prgain[15:13]==7)
-			prgbank=diskbank & {6{Rstate==2|Wstate==2}};
-		else
-			prgbank={4'b0001,prgain[14:13]};
-	end
-	assign ramprgaout={prgbank,prgain[12:0]};
+//bankswitch control: 6000-DFFF = sram, E000-FFFF = bios or disk
+reg [18:13] prgbank;
+wire [18:13] diskbank={1'b1,romoffset[17:13]};
 
-	//mirroring
-	assign ramchraout[18:11]={6'd0,chrain[12:11]};
-	assign ramchraout[10]=!chrain[13]? chrain[10]: ((vertical & chrain[10]) | (!vertical & chrain[11]));
-	assign ciram_ce=chrain[13];
+always@* begin
+	if(prgain[15:13]==7)
+		prgbank=diskbank & {6{Rstate==2|Wstate==2}};
+	else
+		prgbank={4'b0001,prgain[14:13]};
+end
 
-	//expansion audio
-	fds_audio fds_audio
-	(
-		.clk(clk20),
-		.m2(ce),
-		.reset(reset),
-		.wr(nesprg_we),
-		.addr_in(prgain),
-		.data_in(nesprgdin),
-		.data_out(audio_dout),
-		.audio_out(snd_level)
-	);
+assign ramprgaout={prgbank,prgain[12:0]};
+
+//mirroring
+assign ramchraout[18:11]={6'd0,chrain[12:11]};
+assign ramchraout[10]=!chrain[13]? chrain[10]: ((vertical & chrain[10]) | (!vertical & chrain[11]));
+assign ciram_ce=chrain[13];
+
+//expansion audio
+fds_audio fds_audio
+(
+	.clk(clk20),
+	.m2(ce),
+	.reset(reset),
+	.wr(nesprg_we),
+	.addr_in(prgain),
+	.data_in(nesprgdin),
+	.data_out(audio_dout),
+	.audio_out(snd_level)
+);
 
 endmodule
 

--- a/mappers/MMC2.sv
+++ b/mappers/MMC2.sv
@@ -260,11 +260,9 @@ reg latch_0, latch_1;
 
 // Update registers
 always @(posedge clk) 
-if (~enable)
-	{prg_bank, chr_bank_0a, chr_bank_0b, chr_bank_1a, chr_bank_1b, mirroring} <= 0;
-else if (ce) begin
+if (ce) begin
 	if (~enable)
-		prg_bank <= 4'b1110;	  
+		prg_bank <= 4'b1110;
 	else if (prg_write && prg_ain[15]) begin
 		case(prg_ain[14:12])
 			2: prg_bank <= prg_din[3:0];     // $A000
@@ -282,9 +280,7 @@ end
 // PPU reads $1FD8 through $1FDF: latch 1 is set to $FD for subsequent reads
 // PPU reads $1FE8 through $1FEF: latch 1 is set to $FE for subsequent reads
 always @(posedge clk)
-if (~enable)
-	{latch_0, latch_1} <= 0;
-else if (ce && chr_read) begin
+if (ce & chr_read) begin
 	latch_0 <= (chr_ain & 14'h3ff8) == 14'h0fd8 ? 1'd0 : (chr_ain & 14'h3ff8) == 14'h0fe8 ? 1'd1 : latch_0;
 	latch_1 <= (chr_ain & 14'h3ff8) == 14'h1fd8 ? 1'd0 : (chr_ain & 14'h3ff8) == 14'h1fe8 ? 1'd1 : latch_1;
 end

--- a/mappers/MMC2.sv
+++ b/mappers/MMC2.sv
@@ -2,23 +2,47 @@
 
 // MMC2 mapper chip. PRG ROM: 128kB. Bank Size: 8kB. CHR ROM: 128kB
 module MMC2(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,          // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,         // Enable access to memory for the specified operation.
-	input chr_read,
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,         // Allow write
-	output vram_a10,          // Value for A10 address line
-	output vram_ce            // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+
+reg [15:0] flags_out = 0;
 
 // PRG ROM bank select ($A000-$AFFF)
 // 7  bit  0
@@ -75,7 +99,10 @@ reg mirroring;
 reg latch_0, latch_1;
 	
 // Update registers
-always @(posedge clk) if (ce) begin
+always @(posedge clk)
+if (~enable)
+	{prg_bank, chr_bank_0a, chr_bank_0b, chr_bank_1a, chr_bank_1b, mirroring} <= 0;
+else if (ce) begin
 	if (prg_write && prg_ain[15]) begin
 		case(prg_ain[14:12])
 			2: prg_bank <= prg_din[3:0];     // $A000
@@ -92,7 +119,10 @@ end
 // PPU reads $0FE8: latch 0 is set to $FE for subsequent reads
 // PPU reads $1FD8 through $1FDF: latch 1 is set to $FD for subsequent reads
 // PPU reads $1FE8 through $1FEF: latch 1 is set to $FE for subsequent reads
-always @(posedge clk) if (ce && chr_read) begin
+always @(posedge clk)
+if (~enable)
+	{latch_0, latch_1} <= 0;
+else if (ce && chr_read) begin
 	latch_0 <= (chr_ain & 14'h3fff) == 14'h0fd8 ? 1'd0 : (chr_ain & 14'h3fff) == 14'h0fe8 ? 1'd1 : latch_0;
 	latch_1 <= (chr_ain & 14'h3ff8) == 14'h1fd8 ? 1'd0 : (chr_ain & 14'h3ff8) == 14'h1fe8 ? 1'd1 : latch_1;
 end
@@ -132,23 +162,47 @@ endmodule
 
 // MMC4 mapper chip. PRG ROM: 256kB. Bank Size: 16kB. CHR ROM: 128kB
 module MMC4(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,             // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,            // Enable access to memory for the specified operation.
-	input chr_read,
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,            // Allow write
-	output vram_a10,             // Value for A10 address line
-	output vram_ce               // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? prg_dout : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire [7:0] prg_dout = 0;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
 
 // PRG ROM bank select ($A000-$AFFF)
 // 7  bit  0
@@ -205,8 +259,11 @@ reg mirroring;
 reg latch_0, latch_1;
 
 // Update registers
-always @(posedge clk) if (ce) begin
-	if (reset)
+always @(posedge clk) 
+if (~enable)
+	{prg_bank, chr_bank_0a, chr_bank_0b, chr_bank_1a, chr_bank_1b, mirroring} <= 0;
+else if (ce) begin
+	if (~enable)
 		prg_bank <= 4'b1110;	  
 	else if (prg_write && prg_ain[15]) begin
 		case(prg_ain[14:12])
@@ -224,7 +281,10 @@ end
 // PPU reads $0FE8 through $0FEF: latch 0 is set to $FE for subsequent reads
 // PPU reads $1FD8 through $1FDF: latch 1 is set to $FD for subsequent reads
 // PPU reads $1FE8 through $1FEF: latch 1 is set to $FE for subsequent reads
-always @(posedge clk) if (ce && chr_read) begin
+always @(posedge clk)
+if (~enable)
+	{latch_0, latch_1} <= 0;
+else if (ce && chr_read) begin
 	latch_0 <= (chr_ain & 14'h3ff8) == 14'h0fd8 ? 1'd0 : (chr_ain & 14'h3ff8) == 14'h0fe8 ? 1'd1 : latch_0;
 	latch_1 <= (chr_ain & 14'h3ff8) == 14'h1fd8 ? 1'd0 : (chr_ain & 14'h3ff8) == 14'h1fe8 ? 1'd1 : latch_1;
 end

--- a/mappers/MMC3.sv
+++ b/mappers/MMC3.sv
@@ -2,23 +2,49 @@
 
 // iNES mapper 64 and 158 - Tengen's version of MMC3
 module Rambo1(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                             // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                            // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                            // Allow write
-	output vram_a10,                             // Value for A10 address line
-	output vram_ce,                              // True if the address should be routed to the internal 2kB VRAM.
-	output reg irq
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? prg_dout : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+
+wire [21:0] prg_aout, chr_aout;
+wire [7:0] prg_dout = 0;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg irq;
+reg [15:0] flags_out = 0;
 
 reg [3:0] bank_select;             // Register to write to next
 reg prg_rom_bank_mode;             // Mode for PRG banking
@@ -48,7 +74,8 @@ always @(posedge clk) begin
 	a12_ctr <= chr_ain[12] ? 2'b11 : (a12_ctr != 0 && ce) ? a12_ctr - 2'b01 : a12_ctr;
 end
 
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	bank_select <= 0;
 	prg_rom_bank_mode <= 0;
 	chr_K <= 0;
@@ -155,23 +182,49 @@ assign vram_ce = chr_ain[13];
 endmodule
 
 // This mapper also handles mapper 33,47,48,74,76,80,82,88,95,118,119,154,191,192,194,195,206 and 207.
-module MMC3(input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                             // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                            // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                            // Allow write
-	output vram_a10,                             // Value for A10 address line
-	output vram_ce,                              // True if the address should be routed to the internal 2kB VRAM.
-	output irq
+module MMC3 (
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? prg_dout : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire [7:0] prg_dout = 0;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire irq;
+reg [15:0] flags_out = 0;
 
 reg [2:0] bank_select;             // Register to write to next
 reg prg_rom_bank_mode;             // Mode for PRG banking
@@ -225,7 +278,8 @@ wire chr_invert_support = (irq_support && !mapper48) || mapper82;
 wire regs_7e = mapper80 || mapper82 || mapper207;
 wire internal_128 = mapper80 || mapper207;
 
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	irq_reg <= 5'b00000;
 	bank_select <= 0;
 	prg_rom_bank_mode <= 0;
@@ -459,24 +513,48 @@ endmodule
 
 // mapper 165
 module Mapper165(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                   // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                  // Enable access to memory for the specified operation.
-	input chr_read,
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                  // Allow write
-	output vram_a10,                   // Value for A10 address line
-	output vram_ce,                    // True if the address should be routed to the internal 2kB VRAM.
-	output reg irq
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? prg_dout : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire [7:0] prg_dout = 0;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg irq;
+reg [15:0] flags_out = 0;
 
 reg [2:0] bank_select;             // Register to write to next
 reg prg_rom_bank_mode;             // Mode for PRG banking
@@ -496,7 +574,7 @@ wire [7:0] new_counter = (counter == 0 || irq_reload) ? irq_latch : counter - 1'
 reg [3:0] a12_ctr;
 
 always @(posedge clk)
-if (reset) begin
+if (~enable) begin
 	irq <= 0;
 	bank_select <= 0;
 	prg_rom_bank_mode <= 0;

--- a/mappers/Namco.sv
+++ b/mappers/Namco.sv
@@ -1,25 +1,49 @@
 // Namco mappers
 
 module N106(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                   // Read / write signals
-	input [7:0] prg_din,
-	output [7:0] prg_dout,
-	output prg_allow,                  // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                  // Allow write
-	output vram_a10,                   // Value for A10 address line
-	output vram_ce,                    // True if the address should be routed to the internal 2kB VRAM.
-	output irq,
-	output [15:0] audio
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? prg_dout : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire irq;
+reg [15:0] flags_out = 0;
+wire [7:0] prg_dout;
+wire [15:0] audio;
 
 wire nesprg_oe;
 wire [7:0] neschrdout;
@@ -39,7 +63,7 @@ always @(posedge clk) begin
 	m2[0] <= ce;
 end
 
-MAPN106 n106(m2[7], m2_n, clk, reset, prg_write, nesprg_oe, 0,
+MAPN106 n106(m2[7], m2_n, clk, ~enable, prg_write, nesprg_oe, 0,
 	1, prg_ain, chr_ain, prg_din, 8'b0, prg_dout,
 	neschrdout, neschr_oe, chr_allow, chrram_oe, wram_oe, wram_we, prgram_we,
 	prgram_oe, chr_aout[18:10], ramprgaout, irq, vram_ce, exp6,

--- a/mappers/Sunsoft.sv
+++ b/mappers/Sunsoft.sv
@@ -1,22 +1,47 @@
 // 69 - Sunsoft FME-7
 module Mapper69(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read, prg_write,   // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,            // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,            // Allow write
-	output reg vram_a10,         // Value for A10 address line
-	output vram_ce,              // True if the address should be routed to the internal 2kB VRAM.
-	output reg irq,
-	output [15:0] audio
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+reg vram_a10;
+wire vram_ce;
+reg irq;
+reg [15:0] flags_out = 0;
+wire [15:0] audio;
 
 reg [7:0] chr_bank[0:7];
 reg [4:0] prg_bank[0:3];
@@ -27,7 +52,8 @@ reg [3:0] addr;
 reg ram_enable, ram_select;
 wire [16:0] new_irq_counter = irq_counter - {15'b0, irq_countdown};
 
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	chr_bank[0] <= 0;
 	chr_bank[1] <= 0;
 	chr_bank[2] <= 0;
@@ -107,7 +133,7 @@ assign vram_ce = chr_ain[13];
 //audio
 	wire [6:0] fme7_out;
 	wire [15:0] fme7_sample;
-	FME7_sound snd0(clk, ce, reset, prg_write, prg_ain, prg_din, fme7_out);
+	FME7_sound snd0(clk, ce, ~enable, prg_write, prg_ain, prg_din, fme7_out);
 	//FME7_sound snd0(m2, reset, nesprg_we, prgain, nesprgdin, fme7_out);
 	//pdm #(7) pdm_mod(clk20, fme7_out, exp6);
 
@@ -138,7 +164,7 @@ module FME7_sound(
 	reg [11:0] count0,count1,count2;
 	reg [4:0] duty0,duty1,duty2;
 
-	always@(posedge clk, posedge reset) begin
+	always@(posedge clk) begin
 		if(reset) begin
 			en <= 0;
 		end else if (ce) begin
@@ -188,94 +214,120 @@ endmodule
 
 // Mapper 190, Magic Kid GooGoo
 // Mapper 67, Sunsoft-3
-module Mapper67(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,              // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,             // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,             // Allow write
-	output reg vram_a10,          // Value for A10 address line
-	output vram_ce,               // True if the address should be routed to the internal 2kB VRAM.
-	output reg irq
+module Mapper67 (
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
-	reg [7:0] prg_bank_0;
-	reg [7:0] chr_bank_0, chr_bank_1, chr_bank_2, chr_bank_3;
-	reg [1:0] mirroring;
-	reg irq_ack;
-	reg irq_enable;
-	reg irq_low;
-	reg [15:0] irq_counter;
-	wire mapper190 = (flags[7:0] == 190);
 
-	always @(posedge clk) if (reset) begin
-		prg_bank_0 <= 0;
-		chr_bank_0 <= 0;
-		chr_bank_1 <= 0;
-		chr_bank_2 <= 0;
-		chr_bank_3 <= 0;
-		mirroring <= 2'b00; //vertical for mapper190
-		irq_counter <= 0;
-		irq_enable <= 0;
-		irq_low <= 0;
-	end else if (ce) begin
-		irq_ack <= 1'b0;
-		if ((prg_write) && (prg_ain[15])) begin// Cover all from $8000 to $FFFF to maximize compatibility
-			if (!mapper190)
-				casez({prg_ain[14:11],irq_low})
-					5'b000_1_?: chr_bank_0 <= prg_din;
-					5'b001_1_?: chr_bank_1 <= prg_din;
-					5'b010_1_?: chr_bank_2 <= prg_din;
-					5'b011_1_?: chr_bank_3 <= prg_din;
-					5'b110_1_?: mirroring <= prg_din[1:0];
-					5'b111_1_?: prg_bank_0 <= prg_din;
-					5'b100_1_0: {irq_low, irq_counter[15:8]} <= {1'b1,prg_din};
-					5'b100_1_1: {irq_low, irq_counter[7:0]} <= {1'b0,prg_din};
-					5'b101_1_?: {irq_low, irq_ack, irq_enable} <= {2'b01, prg_din[4]};
-				endcase
-			else
-				casez({prg_ain[13],prg_ain[1:0]})
-					3'b0_??: prg_bank_0[3:0] <= {prg_ain[14],prg_din[2:0]};
-					3'b1_00: chr_bank_0 <= prg_din;
-					3'b1_01: chr_bank_1 <= prg_din;
-					3'b1_10: chr_bank_2 <= prg_din;
-					3'b1_11: chr_bank_3 <= prg_din;
-				endcase
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
 
-			if (irq_enable) begin
-				irq_counter <= irq_counter - 16'd1;
-				if (irq_counter == 16'h0) begin
-					irq <= 1'b1; // IRQ
-					irq_enable <= 0;
-				end
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire irq;
+reg [15:0] flags_out = 0;
+
+reg [7:0] prg_bank_0;
+reg [7:0] chr_bank_0, chr_bank_1, chr_bank_2, chr_bank_3;
+reg [1:0] mirroring;
+reg irq_ack;
+reg irq_enable;
+reg irq_low;
+reg [15:0] irq_counter;
+wire mapper190 = (flags[7:0] == 190);
+
+always @(posedge clk)
+if (~enable) begin
+	prg_bank_0 <= 0;
+	chr_bank_0 <= 0;
+	chr_bank_1 <= 0;
+	chr_bank_2 <= 0;
+	chr_bank_3 <= 0;
+	mirroring <= 2'b00; //vertical for mapper190
+	irq_counter <= 0;
+	irq_enable <= 0;
+	irq_low <= 0;
+end else if (ce) begin
+	irq_ack <= 1'b0;
+	if ((prg_write) && (prg_ain[15])) begin// Cover all from $8000 to $FFFF to maximize compatibility
+		if (!mapper190)
+			casez({prg_ain[14:11],irq_low})
+				5'b000_1_?: chr_bank_0 <= prg_din;
+				5'b001_1_?: chr_bank_1 <= prg_din;
+				5'b010_1_?: chr_bank_2 <= prg_din;
+				5'b011_1_?: chr_bank_3 <= prg_din;
+				5'b110_1_?: mirroring <= prg_din[1:0];
+				5'b111_1_?: prg_bank_0 <= prg_din;
+				5'b100_1_0: {irq_low, irq_counter[15:8]} <= {1'b1,prg_din};
+				5'b100_1_1: {irq_low, irq_counter[7:0]} <= {1'b0,prg_din};
+				5'b101_1_?: {irq_low, irq_ack, irq_enable} <= {2'b01, prg_din[4]};
+			endcase
+		else
+			casez({prg_ain[13],prg_ain[1:0]})
+				3'b0_??: prg_bank_0[3:0] <= {prg_ain[14],prg_din[2:0]};
+				3'b1_00: chr_bank_0 <= prg_din;
+				3'b1_01: chr_bank_1 <= prg_din;
+				3'b1_10: chr_bank_2 <= prg_din;
+				3'b1_11: chr_bank_3 <= prg_din;
+			endcase
+
+		if (irq_enable) begin
+			irq_counter <= irq_counter - 16'd1;
+			if (irq_counter == 16'h0) begin
+				irq <= 1'b1; // IRQ
+				irq_enable <= 0;
 			end
-			if (irq_ack)
-				irq <= 1'b0; // IRQ ACK
 		end
+		if (irq_ack)
+			irq <= 1'b0; // IRQ ACK
 	end
+end
 
-	always begin
-		casez({mirroring})
-			2'b00   :   vram_a10 = {chr_ain[10]};    // vertical
-			2'b01   :   vram_a10 = {chr_ain[11]};    // horizontal
-			2'b1?   :   vram_a10 = {mirroring[0]};   // 1 screen lower:upper
-		endcase
-	end
+always begin
+	casez({mirroring})
+		2'b00   :   vram_a10 = {chr_ain[10]};    // vertical
+		2'b01   :   vram_a10 = {chr_ain[11]};    // horizontal
+		2'b1?   :   vram_a10 = {mirroring[0]};   // 1 screen lower:upper
+	endcase
+end
 
 reg [7:0] prgsel;
-	always begin
-		case(prg_ain[14])
-		1'b0: prgsel = prg_bank_0;                // $8000 is swapable
-		1'b1: prgsel = mapper190 ? 8'h00 : 8'hFF; // $C000 is hardwired to first/last bank
-		endcase
-	end
+always begin
+	case(prg_ain[14])
+	1'b0: prgsel = prg_bank_0;                // $8000 is swapable
+	1'b1: prgsel = mapper190 ? 8'h00 : 8'hFF; // $C000 is hardwired to first/last bank
+	endcase
+end
 
 reg [7:0] chrsel;
 always begin
@@ -304,22 +356,46 @@ endmodule
 
 // #68 - Sunsoft-4 - Game After Burner, and some japanese games. MAX: 128kB PRG, 256kB CHR
 module Mapper68(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write, // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,          // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,          // Allow write
-	output vram_a10,           // Value for A10 address line
-	output vram_ce             // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
 
 reg [6:0] chr_bank_0, chr_bank_1, chr_bank_2, chr_bank_3;
 reg [6:0] nametable_0, nametable_1;
@@ -327,7 +403,8 @@ reg [2:0] prg_bank;
 reg use_chr_rom;
 reg mirroring;
 
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	chr_bank_0 <= 0;
 	chr_bank_1 <= 0;
 	chr_bank_2 <= 0;

--- a/mappers/VRC.sv
+++ b/mappers/VRC.sv
@@ -2,22 +2,47 @@
 
 // VRC1 (75)
 module VRC1(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,            // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,           // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,           // Allow write
-	output reg vram_a10,        // Value for A10 address line
-	output vram_ce              // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+reg vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 reg [3:0] prg_bank0, prg_bank1, prg_bank2;
 reg [4:0] chr_bank0, chr_bank1;
 reg [1:0] mirroring;
@@ -25,7 +50,7 @@ reg [3:0] prg_tmp;
 reg [4:0] chr_tmp;
 
 always @(posedge clk)
-	if (reset) begin
+	if (~enable) begin
 		// Set value for mirroring
 		mirroring[1:0] <= {flags[16], !flags[14]};
 	end else if (ce) begin
@@ -74,23 +99,48 @@ endmodule
 
 // VRC3 (73)
 module VRC3(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                             // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                            // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                            // Allow write
-	output vram_a10,                             // Value for A10 address line
-	output vram_ce,                              // True if the address should be routed to the internal 2kB VRAM.
-	output reg irq
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg irq;
+reg [15:0] flags_out = 0;
+
 
 reg [2:0] prg_bank;
 reg [4:0] irq_enable;
@@ -98,7 +148,7 @@ reg [15:0] irq_latch;
 reg [15:0] irq_counter;
 
 always @(posedge clk)
-if (reset) begin
+if (~enable) begin
 	// Set value for mirroring
 	irq <= 0;
 	prg_bank <= 0;
@@ -152,23 +202,48 @@ endmodule
 
 // VRC2 and VRC4
 module VRC24(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                             // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                            // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                            // Allow write
-	output reg vram_a10,                         // Value for A10 address line
-	output vram_ce,                              // True if the address should be routed to the internal 2kB VRAM.
-	output irq
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire irq;
+reg [15:0] flags_out = 0;
+
 
 reg [4:0] prg_bank0, prg_bank1;
 reg [8:0] chr_bank0, chr_bank1, chr_bank2, chr_bank3, chr_bank4, chr_bank5, chr_bank6, chr_bank7;
@@ -187,7 +262,7 @@ wire [1:0] registers = {mapper21 ?  {(prg_ain[7]|prg_ain[2]),(prg_ain[6]|prg_ain
 								/*mapper25*/{(prg_ain[2]|prg_ain[0]),(prg_ain[3]|prg_ain[1])}};
 
 always @(posedge clk)
-	if (reset) begin
+	if (~enable) begin
 		// Set value for mirroring
 		mirroring[1:0] <= {1'b0, !flags[14]};
 		prg_invert <= 0;
@@ -277,30 +352,54 @@ wire irqc  = {prg_ain[15:12],registers[1:0]}==6'b1111_10; // 0xF002
 wire irqa  = {prg_ain[15:12],registers[1:0]}==6'b1111_11; // 0xF003
 wire irqout;
 assign irq = irqout & mapperVRC4;
-vrcIRQ vrc4irq(clk,reset,prg_write,{irqlh,irqll},irqc,irqa,prg_din,irqout,ce);
+vrcIRQ vrc4irq(clk,enable,prg_write,{irqlh,irqll},irqc,irqa,prg_din,irqout,ce);
 
 endmodule
 
 module VRC6(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                             // Read / write signals
-	input [7:0] prg_din,
-	output [7:0] prg_dout,
-	output prg_allow,                            // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                            // Allow write
-	output vram_a10,                             // Value for A10 address line
-	output vram_ce,                              // True if the address should be routed to the internal 2kB VRAM.
-	output irq,
-	output [15:0] audio
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? prg_dout : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire [7:0] prg_dout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire irq;
+wire [15:0] audio;
+reg [15:0] flags_out = 0;
 
 wire nesprg_oe;
 wire [7:0] neschrdout;
@@ -320,7 +419,7 @@ always @(posedge clk) begin
 	m2[0] <= ce;
 end
 
-MAPVRC6 vrc6(m2[7], m2_n, clk, reset, prg_write, nesprg_oe, 0,
+MAPVRC6 vrc6(m2[7], m2_n, clk, enable, prg_write, nesprg_oe, 0,
 	1, prg_ain, chr_ain, prg_din, 8'b0, prg_dout,
 	neschrdout, neschr_oe, chr_allow, chrram_oe, wram_oe, wram_we, prgram_we,
 	prgram_oe, chr_aout[18:10], ramprgaout, irq, vram_ce, exp6,
@@ -340,24 +439,48 @@ assign prg_allow = (prg_ain[15] && !prg_write) || prg_is_ram;
 endmodule
 
 module VRC7(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                             // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                            // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                            // Allow write
-	output vram_a10,                             // Value for A10 address line
-	output vram_ce,                              // True if the address should be routed to the internal 2kB VRAM.
-	output irq,
-	output [15:0] audio
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? irq : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire irq;
+reg [15:0] flags_out = 0;
+wire [15:0] audio;
 
 assign chr_aout[21:18] = 4'b1000;
 assign chr_aout[9:0] = chr_ain[9:0];
@@ -383,7 +506,7 @@ wire prg_ain43 = prg_ain[4] ^ prg_ain[3];
 reg ramw, soff;
 
 always@(posedge clk) begin
-	if (reset)
+	if (~enable)
 		soff <= 1'b0;
 	if(ce && prg_write) begin
 		casex({prg_ain[15:12],prg_ain43})
@@ -431,7 +554,7 @@ wire irql = {prg_ain[15:12],prg_ain43}==5'b11101; // 0xE008 or 0xE010
 wire irqc = {prg_ain[15:12],prg_ain43}==5'b11110; // 0xF000
 wire irqa = {prg_ain[15:12],prg_ain43}==5'b11111; // 0xF008 or 0xF010
 
-vrcIRQ vrc7irq(clk,reset,prg_write,{irql,irql},irqc,irqa,prg_din,irq,ce);
+vrcIRQ vrc7irq(clk,enable,prg_write,{irql,irql},irqc,irqa,prg_din,irq,ce);
 
 reg [3:0] ce_count;
 always@(posedge clk) begin
@@ -445,7 +568,7 @@ wire ack;
 wire ce_ym2143 = ce | (ce_count==4'd5);
 wire [13:0] ym2143audio;
 wire wr_audio = prg_write && (prg_ain[15:6]==10'b1001_0000_00) && (prg_ain[4:0]==5'b1_0000); //0x9010 or 0x9030
-eseopll ym2143vrc7 (clk,reset, ce_ym2143,wr_audio,ce_ym2143,ack,wr_audio,{15'b0,prg_ain[5]},prg_din,ym2143audio);
+eseopll ym2143vrc7 (clk,~enable, ce_ym2143,wr_audio,ce_ym2143,ack,wr_audio,{15'b0,prg_ain[5]},prg_din,ym2143audio);
 
 //No clipping. Lower volume.
 //wire [12:0] ym2143audiounsigned = ym2143audio[12:0] ^ 13'b1_0000_0000_0000; // 10 bits * 6 channels = Max 13 bits.
@@ -465,7 +588,7 @@ module MAPVRC6(     //signal descriptions in powerpak.v
 	input m2_n,
 	input clk20,
 
-	input reset,
+	input enable,
 	input nesprg_we,
 	output nesprg_oe,
 	input neschr_rd,
@@ -518,7 +641,10 @@ module MAPVRC6(     //signal descriptions in powerpak.v
 	wire irqc = {ain[15:12],ain[1:0]}==6'b111101;
 	wire irqa = {ain[15:12],ain[1:0]}==6'b111110;
 	always@(posedge clk20) begin
-		if(ce && nesprg_we) begin
+		if (~enable)
+			{prgbank8, prgbankC, mirror, chrbank0, chrbank1, chrbank2,
+				chrbank3, chrbank4, chrbank5, chrbank6, chrbank7} <= 0;
+		else if(ce && nesprg_we) begin
 			casex({ain[15:12],ain[1:0]})
 				6'b1000xx:prgbank8<=nesprgdin[4:0]; //800x
 				6'b1100xx:prgbankC<=nesprgdin[5:0]; //C00x
@@ -559,7 +685,7 @@ module MAPVRC6(     //signal descriptions in powerpak.v
 		endcase
 	end
 
-	vrcIRQ vrc6irq(clk20,reset,nesprg_we,{irql,irql},irqc,irqa,nesprgdin,irq,ce);
+	vrcIRQ vrc6irq(clk20,enable,nesprg_we,{irql,irql},irqc,irqa,nesprgdin,irq,ce);
 
 //mirroring
 	assign ramchraout[10]=!chrain[13] ? chrbank[10] : ((mirror==0 & chrain[10]) | (mirror==1 & chrain[11]) | (mirror==3));
@@ -594,7 +720,7 @@ module MAPVRC6(     //signal descriptions in powerpak.v
 	wire [3:0] vrc6sq1_out;
 	wire [3:0] vrc6sq2_out;
 	wire [4:0] vrc6saw_out;
-	vrc6sound snd(clk20, ce, reset, nesprg_we, ain, nesprgdin, vrc6sq1_out, vrc6sq2_out, vrc6saw_out);
+	vrc6sound snd(clk20, ce, enable, nesprg_we, ain, nesprgdin, vrc6sq1_out, vrc6sq2_out, vrc6saw_out);
 //    vrc6sound snd(m2, reset, nesprg_we, ain, nesprgdin, vrc6_out);
 //    pdm #(6) pdm_mod(clk20, vrc6_out, exp6);
 
@@ -608,7 +734,7 @@ endmodule
 
 module vrcIRQ(
 	input clk20,
-	input reset,
+	input enable,
 	input nesprg_we,
 	input [1:0] irqlatch_add,
 	input irqctrl_add,
@@ -621,7 +747,9 @@ module vrcIRQ(
 reg [7:0] irqlatch;
 reg irqM,irqE,irqA;
 always@(posedge clk20) begin
-	if(ce && nesprg_we) begin
+	if (~enable)
+		{irqM, irqA, irqlatch} <= 0;
+	else if(ce && nesprg_we) begin
 		if (irqlatch_add == 2'b11)
 			irqlatch<=nesprgdin;                      //F000
 		else if (irqlatch_add == 2'b10)
@@ -641,7 +769,9 @@ reg [1:0] line;
 wire irqclk=irqM|(scalar==0);
 wire setE=nesprg_we & irqctrl_add & nesprgdin[1];
 always@(posedge clk20) begin
-	if(setE) begin
+	if (~enable)
+		{irqcnt, scalar, line} <= 0;
+	else if(setE) begin
 		scalar<=113;
 		line<=0;
 		irqcnt<=irqlatch;
@@ -660,8 +790,9 @@ always@(posedge clk20) begin
 		end
 	end
 end
+
 always@(posedge clk20) begin
-	if(reset) begin
+	if(~enable) begin
 		irqE<=0;
 		timeout<=0;
 	end else if (ce) begin
@@ -686,7 +817,7 @@ module vrc6sound(
 //	input m2,
 	input clk,
 	input ce,
-	input reset,
+	input enable,
 	input wr,
 	input [15:0] ain,
 	input [7:0] din,
@@ -709,8 +840,8 @@ reg [3:0] duty0cnt, duty1cnt;
 reg [2:0] duty2cnt;
 reg [7:0] acc;
 
-always@(posedge clk, posedge reset) begin
-	if(reset) begin
+always@(posedge clk) begin
+	if(~enable) begin
 		en0<=0;
 		en1<=0;
 		en2<=0;

--- a/mappers/generic.sv
+++ b/mappers/generic.sv
@@ -154,7 +154,7 @@ assign audio_b      = enable ? audio_in : 16'hZ;
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
 wire chr_allow;
-wire vram_a10;
+reg vram_a10;
 wire vram_ce;
 reg [15:0] flags_out = 0;
 
@@ -493,7 +493,7 @@ assign audio_b      = enable ? audio_in : 16'hZ;
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
 wire chr_allow;
-wire vram_a10;
+reg vram_a10;
 wire vram_ce;
 reg [15:0] flags_out = 0;
 
@@ -722,7 +722,7 @@ assign audio_b      = enable ? audio_in : 16'hZ;
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
 wire chr_allow;
-wire vram_a10;
+reg vram_a10;
 wire vram_ce;
 reg [15:0] flags_out = 0;
 

--- a/mappers/generic.sv
+++ b/mappers/generic.sv
@@ -2,21 +2,47 @@
 
 // No mapper chip
 module MMC0(
-	input clk,
-	input ce,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read, 
-	input prg_write,             // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                      // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                      // Allow write
-	output vram_a10,                       // Value for A10 address line
-	output vram_ce                         // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 
 assign prg_aout = {7'b00_0000_0, prg_ain[14:0]};
 assign prg_allow = prg_ain[15] && !prg_write;
@@ -29,26 +55,50 @@ endmodule
 
 // #13 - CPROM - Used by Videomation
 module Mapper13(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                       // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                      // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                      // Allow write
-	output vram_a10,                       // Value for A10 address line
-	output vram_ce                         // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
 
 reg [1:0] chr_bank;
 always @(posedge clk) begin
-	if (reset) begin
+	if (~enable) begin
 		chr_bank <= 0;
 	end else if (ce) begin
 		if (prg_ain[15] && prg_write)
@@ -67,22 +117,47 @@ endmodule
 
 // 30-UNROM512
 module Mapper30(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                   // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                  // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                  // Allow write
-	output reg vram_a10,               // Value for A10 address line
-	output vram_ce                     // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 
 reg [4:0] prgbank;
 reg [1:0] chrbank;
@@ -90,7 +165,7 @@ reg [2:0] mirror;
 wire four_screen = (mirror[2:1] == 2'b11);
 
 always @(posedge clk) begin
-	if (reset) begin
+	if (~enable) begin
 		// Set value for mirroring
 		mirror[2:1] <= {flags[16], flags[14]};
 	end else if (ce) begin
@@ -128,22 +203,47 @@ endmodule
 // 140 - Jaleco JF-11,JF-14
 // 66 - GxROM
 module Mapper66(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                   // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                  // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                  // Allow write
-	output vram_a10,                   // Value for A10 address line
-	output vram_ce                     // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 
 reg [1:0] prg_bank;
 reg [3:0] chr_bank;
@@ -155,7 +255,8 @@ wire Mapper101 = (mapper == 101);
 wire Mapper86 = (mapper == 86);
 wire Mapper87 = (mapper == 87);
 
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	prg_bank <= 0;
 	chr_bank <= 0;
 end else if (ce) begin
@@ -191,28 +292,54 @@ endmodule
 
 // 34 - BxROM or NINA-001
 module Mapper34(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                       // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                      // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                      // Allow write
-	output vram_a10,                       // Value for A10 address line
-	output vram_ce                         // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 
 reg [5:0] prg_bank;
 reg [3:0] chr_bank_0, chr_bank_1;
 
 wire NINA = (flags[13:11] != 0); // NINA is used when there is more than 8kb of CHR
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	prg_bank <= 0;
 	chr_bank_0 <= 0;
 	chr_bank_1 <= 1; // To be compatible with BxROM
@@ -247,27 +374,52 @@ endmodule
 
 // #71,#232 - Camerica
 module Mapper71(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                    // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                   // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                   // Allow write
-	output vram_a10,                    // Value for A10 address line
-	output vram_ce                      // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
 
 reg [3:0] prg_bank;
 reg ciram_select;
 wire mapper232 = (flags[7:0] == 232);
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	prg_bank <= 0;
 	ciram_select <= 0;
 end else if (ce) begin
@@ -304,28 +456,53 @@ endmodule
 
 // 77-IREM
 module Mapper77(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                   // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                  // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                  // Allow write
-	output reg vram_a10,               // Value for A10 address line
-	output vram_ce                     // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 
 reg [3:0] prgbank;
 reg [3:0] chrbank;
 
 always @(posedge clk) begin
-	if (reset) begin
+	if (~enable) begin
 		prgbank <= 0;
 		chrbank <= 0;
 	end else if (ce) begin
@@ -352,22 +529,46 @@ endmodule
 // #78-IREM-HOLYDIVER/JALECO-JF-16
 // #70,#152-Bandai
 module Mapper78(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                       // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                      // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                      // Allow write
-	output vram_a10,                       // Value for A10 address line
-	output vram_ce                         // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
 
 reg [3:0] prg_bank;
 reg [3:0] chr_bank;
@@ -376,7 +577,7 @@ wire mapper70 = (flags[7:0] == 70);
 wire mapper152 = (flags[7:0] == 152);
 wire onescreen = (flags[22:21] == 1) | mapper152; // default (0 or 3) Holy Diver submapper; (1) JALECO-JF-16
 always @(posedge clk) begin
-	if (reset) begin
+	if (~enable) begin
 		prg_bank <= 0;
 		chr_bank <= 0;
 		mirroring <= flags[14];
@@ -415,29 +616,54 @@ endmodule
 
 // #79,#113 - NINA-03 / NINA-06
 module Mapper79(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,               // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,              // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,              // Allow write
-	output vram_a10,               // Value for A10 address line
-	output vram_ce                 // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
 
 reg [2:0] prg_bank;
 reg [3:0] chr_bank;
 reg mirroring;  // 0: Horizontal, 1: Vertical
 wire mapper113 = (flags[7:0] == 113); // NINA-06
 
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	prg_bank <= 0;
 	chr_bank <= 0;
 	mirroring <= 0;
@@ -459,22 +685,47 @@ endmodule
 
 // #89,#93,#184 - Sunsoft mappers
 module Mapper89(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                   // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                  // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                  // Allow write
-	output reg vram_a10,               // Value for A10 address line
-	output vram_ce                     // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 
 reg [2:0] prgsel;
 reg [3:0] chrsel0;
@@ -489,7 +740,8 @@ wire mapper89 = (mapper == 8'd89);
 wire mapper93 = (mapper == 8'd93);
 wire mapper184 = (mapper == 8'd184);
 
-always @(posedge clk) if (reset) begin
+always @(posedge clk)
+if (~enable) begin
 	prgsel <= 3'b110;
 	chrsel0 <= 4'b1111;
 	chrsel1 <= 4'b1111;
@@ -539,27 +791,52 @@ endmodule
 
 // 107 Magicseries Magic Dragon
 module Mapper107(
-	input clk,
-	input ce,
-	input reset,
-	input [31:0] flags,
-	input [15:0] prg_ain,
-	output [21:0] prg_aout,
-	input prg_read,
-	input prg_write,                   // Read / write signals
-	input [7:0] prg_din,
-	output prg_allow,                  // Enable access to memory for the specified operation.
-	input [13:0] chr_ain,
-	output [21:0] chr_aout,
-	output chr_allow,                  // Allow write
-	output vram_a10,                   // Value for A10 address line
-	output vram_ce                     // True if the address should be routed to the internal 2kB VRAM.
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
 );
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+reg [15:0] flags_out = 0;
+
 
 reg [6:0] prg_bank;
 reg [7:0] chr_bank;
 always @(posedge clk) begin
-	if (reset) begin
+	if (~enable) begin
 		prg_bank <= 0;
 		chr_bank <= 0;
 	end else if (ce) begin
@@ -576,5 +853,180 @@ assign prg_allow = prg_ain[15] && !prg_write;
 assign chr_allow = flags[15];
 assign chr_aout = {2'b10, chr_bank[6:0], chr_ain[12:0]};
 assign vram_ce = chr_ain[13];
+
+endmodule
+
+// Tepples/Multi-discrete mapper
+// This mapper can emulate other mappers,  such as mapper #0, mapper #2
+module Mapper28(
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	inout  [7:0] chr_dout_b,  // chr data (non standard)
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, 0, prg_conflict, prg_open_bus, has_chr_dout}
+);
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_dout_b   = enable ? chr_dout : 8'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? audio_in : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+reg vram_a10;
+reg [7:0] chr_dout;
+wire vram_ce;
+wire [15:0] flags_out = {13'h0, prg_conflict, prg_open_bus, has_chr_dout};
+
+wire prg_open_bus, prg_conflict, has_chr_dout;
+
+reg [6:0] a53prg;    // output PRG ROM (A14-A20 on ROM)
+reg [1:0] a53chr;    // output CHR RAM (A13-A14 on RAM)
+
+reg [3:0] inner;    // "inner" bank at 01h
+reg [5:0] mode;     // mode register at 80h
+reg [5:0] outer;    // "outer" bank at 81h
+reg [2:0] selreg;   // selector register
+reg [3:0] security; // selector register
+
+// Allow writes to 0x5000 only when launching through the proper mapper ID.
+wire [7:0] mapper = flags[7:0];
+wire allow_select = (mapper == 8'd28);
+wire extend_bit = (mapper == 97);
+
+always @(posedge clk)
+if (~enable) begin
+	mode[5:2] <= 0;         // NROM mode, 32K mode
+	outer[5:0] <= 6'h3f;    // last bank
+	inner <= 0;
+	selreg <= 1;
+
+	// Set value for mirroring
+	if (mapper == 2 || mapper == 0 || mapper == 3 || mapper == 94 || mapper == 180 || mapper == 185)
+		mode[1:0] <= flags[14] ? 2'b10 : 2'b11;
+
+	// UNROM #2 - Current bank in $8000-$BFFF and fixed top half of outer bank in $C000-$FFFF
+	if (mapper == 2) begin
+		mode[5:2] <= 4'b1111; // 256K banks, UNROM mode
+	end
+
+	// CNROM #3 - Fixed PRG bank, switchable CHR bank.
+	if (mapper == 3)
+		selreg <= 0;
+
+	// CNROM #185 - Fixed PRG bank, Fixed CHR Bank, Security.
+	if (mapper == 185)
+		selreg <= 4;
+
+	// UNROM #180 - Fixed first PRG bank, Fixed CHR Bank.
+	if (mapper == 180) begin
+		selreg <= 1;
+		mode[5:2] <= 4'b1110;
+		outer[5:0] <= 6'h00;
+	end
+
+	// IREM TAM-S1 IC #97 - Fixed first PRG bank, Fixed CHR Bank, Mirroring.
+	if (mapper == 97) begin
+		selreg <= 6;
+		mode[5:2] <= 4'b1110;
+		outer[5:0] <= 6'h3F;
+	end
+
+	// IREM TAM-S1 IC #94 - Fixed last PRG bank, Fixed CHR Bank
+	if (mapper == 94) begin
+		selreg <= 7;
+		mode[5:2] <= 4'b1111;
+	end
+
+	// AxROM #7 - Switch 32kb rom bank + switchable nametables
+	if (mapper == 7) begin
+		mode[1:0] <= 2'b00;   // Switchable VRAM page.
+		mode[5:2] <= 4'b1100; // 256K banks, (B)NROM mode
+		outer[5:0] <= 6'h00;
+	end
+end else if (ce) begin
+	if ((prg_ain[15:12] == 4'h5) & prg_write && allow_select)
+			selreg <= {1'b0,prg_din[7], prg_din[0]};        // select register
+	if (prg_ain[15] & prg_write) begin
+		casez (selreg)
+			3'b000:  {mode[0], a53chr}  <= {(mode[1] ? mode[0] : prg_din[4]), prg_din[1:0]};     // CHR RAM bank
+			3'b001:  {mode[0], inner}   <= {(mode[1] ? mode[0] : prg_din[4]), prg_din[3:0]};     // "inner" bank
+			3'b010:  {mode}             <= {prg_din[5:0]};                                       // mode register
+			3'b011:  {outer}            <= {prg_din[5:0]};                                       // "outer" bank
+			3'b10?:  {security}         <= {prg_din[5:4],prg_din[1:0]};                          // security
+			3'b110:  {mode[1:0],inner}  <= {prg_din[7] ^ prg_din[6], prg_din[6], prg_din[3:0]};  // "inner" bank
+			3'b111:  {inner}            <= {prg_din[5:2]};                                       // "inner" bank
+		endcase
+	end
+end
+
+always begin
+	// mirroring mode
+	casez(mode[1:0])
+		2'b0? : vram_a10 = {mode[0]};        // 1 screen lower
+		2'b10 : vram_a10 = {chr_ain[10]};    // vertical
+		2'b11 : vram_a10 = {chr_ain[11]};    // horizontal
+	endcase
+
+	// PRG ROM bank size select
+	casez({mode[5:2], prg_ain[14]})
+		5'b00_0?_?: a53prg = {outer[5:0],             prg_ain[14]};  // 32K banks, (B)NROM mode
+		5'b01_0?_?: a53prg = {outer[5:1], inner[0],   prg_ain[14]};  // 64K banks, (B)NROM mode
+		5'b10_0?_?: a53prg = {outer[5:2], inner[1:0], prg_ain[14]};  // 128K banks, (B)NROM mode
+		5'b11_0?_?: a53prg = {outer[5:3], inner[2:0], prg_ain[14]};  // 256K banks, (B)NROM mode
+
+		5'b00_10_1,
+		5'b00_11_0: a53prg = {outer[5:0], inner[0]};                 // 32K banks, UNROM mode
+		5'b01_10_1,
+		5'b01_11_0: a53prg = {outer[5:1], inner[1:0]};               // 64K banks, UNROM mode
+		5'b10_10_1,
+		5'b10_11_0: a53prg = {outer[5:2], inner[2:0]};               // 128K banks, UNROM mode
+		5'b11_10_1,
+		5'b11_11_0: a53prg = {outer[5:3], inner[3:0]};               // 256K banks, UNROM mode
+
+		default: a53prg = {outer[5:0], extend_bit ? outer[0] : prg_ain[14]};  // 16K fixed bank
+	endcase
+
+	chr_dout = 8'hFF;//chr_ain[7:0]; // return open bus = LSB of address? below when CHR disabled by security
+end
+
+assign vram_ce = chr_ain[13];
+assign prg_aout = {1'b0, (a53prg & 7'b0011111), prg_ain[13:0]};
+assign prg_allow = prg_ain[15] && !prg_write;
+assign prg_conflict = prg_ain[15] && (mapper == 3) && (submapper != 1);
+assign prg_open_bus = (prg_ain[15:13] == 3'b011) && (mapper == 7);
+assign chr_allow = flags[15];
+assign chr_aout = {7'b10_0000_0, a53chr, chr_ain[12:0]};
+wire [4:0] submapper = flags[24:21];
+assign has_chr_dout = (mapper == 185) && (((submapper == 0) && (security[1:0] == 2'b00))
+		|| ((submapper == 4) && (security[1:0] != 2'b00))
+		|| ((submapper == 5) && (security[1:0] != 2'b01))
+		|| ((submapper == 6) && (security[1:0] != 2'b10))
+		|| ((submapper == 7) && (security[1:0] != 2'b11)));
 
 endmodule

--- a/mappers/misc.sv
+++ b/mappers/misc.sv
@@ -147,9 +147,9 @@ assign audio_b      = enable ? audio_in : 16'hZ;
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
 wire chr_allow;
-wire vram_a10;
+reg vram_a10;
 wire vram_ce;
-wire irq;
+reg irq;
 reg [15:0] flags_out = 0;
 wire [7:0] prg_dout;
 
@@ -342,8 +342,8 @@ assign audio_b      = enable ? audio_in : 16'hZ;
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
 wire chr_allow;
-wire vram_a10;
-wire irq;
+reg vram_a10;
+reg irq;
 wire [7:0] prg_dout;
 wire vram_ce;
 reg [15:0] flags_out = 0;
@@ -531,7 +531,7 @@ assign audio_b      = enable ? audio_in : 16'hZ;
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
 wire chr_allow;
-wire vram_a10;
+reg vram_a10;
 wire vram_ce;
 reg [15:0] flags_out = 0;
 
@@ -652,7 +652,7 @@ wire prg_allow;
 wire chr_allow;
 wire vram_a10;
 wire vram_ce;
-wire irq;
+reg irq;
 reg [15:0] flags_out = 0;
 
 
@@ -756,9 +756,9 @@ assign audio_b      = enable ? audio_in : 16'hZ;
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
 wire chr_allow;
-wire vram_a10;
+reg vram_a10;
 wire vram_ce;
-wire irq;
+reg irq;
 reg [15:0] flags_out = 0;
 
 reg [7:0] prg_bank_0, prg_bank_1, prg_bank_2;
@@ -1173,7 +1173,6 @@ wire chr_allow;
 wire vram_a10;
 wire vram_ce;
 reg [15:0] flags_out = 0;
-
 
 reg [3:0] prg_bank;
 reg [3:0] chr_bank;

--- a/nes.v
+++ b/nes.v
@@ -296,45 +296,47 @@ module NES(input clk, input reset, input ce,
   
   cart_top multi_mapper (
     // FPGA specific
-    .clk               (clk), 
+    .clk               (clk),
     .reset             (reset),
-    .flags             (mapper_flags),        // iNES header data (use 0 while loading)
-    .ppuflags          (mapper_ppu_flags),    // Cheat for MMC5
+    .flags             (mapper_flags),            // iNES header data (use 0 while loading)
     // Cart pins (slightly abstracted)
-    .ce                (cart_ce & ~reset),    // M2 (held in high impedance during reset)
-    .ppu_ce            (ce),                  // PPU Clock
-    .prg_ain           (prg_addr), 
-    .prg_aout          (prg_linaddr), 
-    .prg_read          (prg_read), 
-    .prg_write         (prg_write), 
-    .prg_din           (prg_din), 
-    .prg_dout          (prg_dout_mapper), 
-    .prg_from_ram      (from_data_bus), 
-    .prg_allow         (prg_allow), 
-    .chr_read          (chr_read),
-    .chr_write         (chr_write), 
-    .chr_din           (chr_from_ppu), 
-    .chr_ain           (chr_addr), 
-    .chr_aout          (chr_linaddr), 
-    .chr_dout          (chr_from_ppu_mapper), 
-    .chr_allow         (chr_allow),
-    .vram_a10          (vram_a10), 
-    .vram_ce           (vram_ce),
-    .irq               (mapper_irq),
-    .audio_in          (16'h0),              // Amplified and inverted APU audio
-    .audio             (sample_ext),
-    // Output flags
-    .has_chr_dout      (has_chr_from_ppu_mapper), 
-    .prg_open_bus      (prg_open_bus),
-    .prg_conflict      (prg_conflict),
+    .ce                (cart_ce),        // M2 (held in high impedance during reset)
+    .prg_ain           (prg_addr),                // CPU Address in (a15 abstracted from ROMSEL)
+    .prg_read          (prg_read),                // CPU RnW split
+    .prg_write         (prg_write),               // CPU RnW split
+    .prg_din           (prg_din),                 // CPU Data bus in (split from bid)
+    .prg_dout          (prg_dout_mapper),         // CPU Data bus out (split from bid)
+    .chr_ain           (chr_addr),                // PPU address in
+    .chr_read          (chr_read),                // PPU read (inverted, active high)
+    .chr_write         (chr_write),               // PPU write (inverted, active high)
+    .chr_din           (chr_from_ppu),            // PPU data bus in (split from bid)
+    .chr_dout          (chr_from_ppu_mapper),     // PPU data bus in (split from bid)
+    .vram_a10          (vram_a10),                // CIRAM a10 line
+    .vram_ce           (vram_ce),                 // CIRAM chip enable
+    .irq               (mapper_irq),              // IRQ (inverted, active high)
+    .audio_in          (16'h0),                   // Amplified and inverted APU audio
+    .audio             (sample_ext),              // Mixed audio output from cart
+    // SDRAM Communication
+    .prg_aout          (prg_linaddr),             // SDRAM adjusted PRG RAM address
+    .prg_allow         (prg_allow),               // Simulates internal CE/Locking
+    .chr_aout          (chr_linaddr),             // SDRAM adjusted CHR RAM address
+    .chr_allow         (chr_allow),               // Simulates internal CE/Locking
     // External hardware interface (EEPROM)
-    .mapper_addr       (bram_addr), 
-    .mapper_data_in    (bram_din), 
-    .mapper_data_out   (bram_dout), 
-    .mapper_prg_write  (bram_write), 
-    .mapper_ovr        (bram_override), 
+    .mapper_addr       (bram_addr),
+    .mapper_data_in    (bram_din),
+    .mapper_data_out   (bram_dout),
+    .mapper_prg_write  (bram_write),
+    .mapper_ovr        (bram_override),
+    // Cheats
+    .prg_from_ram      (from_data_bus),           // Hacky cpu din <= get rid of this!
+    .ppuflags          (mapper_ppu_flags),        // Cheat for MMC5
+    .ppu_ce            (ce),                      // PPU Clock (cheat for MMC5/2/4)
+    // Behavior helper flags
+    .has_chr_dout      (has_chr_from_ppu_mapper), // Output specific data for CHR rather than from SDRAM
+    .prg_open_bus      (prg_open_bus),            // Simulate open bus
+    .prg_conflict      (prg_conflict),            // Simulate bus conflicts
     // User input
-    .fds_swap          (fds_swap)
+    .fds_swap          (fds_swap)                 // Used to trigger FDS disk changes
   );
 
   assign chr_to_ppu = has_chr_from_ppu_mapper ? chr_from_ppu_mapper : memory_din_ppu;
@@ -371,7 +373,7 @@ module NES(input clk, input reset, input ce,
   
   always @* begin
     if (reset)
-		from_data_bus = 0;
+      from_data_bus = 0;
     else if (apu_cs) begin
       if (joypad1_cs)
         from_data_bus = {5'b01000, mic, 1'b0, joypad_data[0]};

--- a/ppu.sv
+++ b/ppu.sv
@@ -146,7 +146,7 @@ module ClockGen(input clk, input ce, input reset,
     // The pre render flag is set while we're on scanline -1.
     is_pre_render <= exiting_vblank;
     
-    //if (exiting_vblank) second_frame <= !second_frame;
+    if (exiting_vblank) second_frame <= !second_frame;
   end
   
 endmodule // ClockGen

--- a/ppu.sv
+++ b/ppu.sv
@@ -661,10 +661,13 @@ module PPU(input clk, input ce, input reset,   // input clock  21.48 MHz / 4. 1 
 //  end
 
  
-  always @(posedge clk) if (ce) begin
+  always @(posedge clk) 
+  if (ce) begin
 //    if (!is_in_vblank && write)
 //      $write("%d/%d: $200%d <= %x\n", scanline, cycle, ain, din);
-    if (write) begin
+    if (reset) begin
+      vbl_enable <= 0;
+    end else if (write) begin
       case (ain)
       0: begin // PPU Control Register 1
       // t:....BA.. ........ = d:......BA


### PR DESCRIPTION
Further refactored mappers, cleaning up wires, ports, and correcting behavior of reset. In addition, mappers are now disabled when not selected, so that they do not create and maintain state incorrectly.

I also added a little documentation for each mapper to make testing and work easier.

Also:
-fixed power on/reset state of of PPU (thanks greyrogue) that caused some games (akamajou densestsu) to not load consistently.
-fixed PPU sync that was causing some NMI instability and causing some tests to fail. 

Now that most cleanup is done, the next thing I will do correct audio mixing in the cart mapper rather than at system level.