### PR TITLE
Mapper cleanup final phase

### DIFF
--- a/NES.qsf
+++ b/NES.qsf
@@ -351,6 +351,8 @@ set_location_assignment PIN_W20 -to SW[3]
 
 set_global_assignment -name PRE_FLOW_SCRIPT_FILE "quartus_sh:sys/build_id.tcl"
 
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
+set_global_assignment -name VERILOG_FILE jt49_dcrm2.v
 set_global_assignment -name SYSTEMVERILOG_FILE mappers/VRC.sv
 set_global_assignment -name SYSTEMVERILOG_FILE mappers/Sunsoft.sv
 set_global_assignment -name SYSTEMVERILOG_FILE mappers/Namco.sv

--- a/NES.sv
+++ b/NES.sv
@@ -102,9 +102,9 @@ module emu
 
 assign USER_OUT = '1;
 
-assign AUDIO_S   = 0;
-assign AUDIO_L   = sample;
-assign AUDIO_R   = sample;
+assign AUDIO_S   = 1'b1;
+assign AUDIO_L   = {~sample[15], sample[14:0]};
+assign AUDIO_R   = AUDIO_L;
 assign AUDIO_MIX = 0;
 
 assign LED_USER  = downloading | (loader_fail & led_blink) | bk_state;

--- a/NES.sv
+++ b/NES.sv
@@ -184,6 +184,8 @@ wire int_audio = 1;
 `endif
 
 // Remove DC offset and convert to signed
+// At this CE rate, it also slightly lowers the bass to
+// better imitate the real high pass of the system.
 jt49_dcrm2 #(.sw(16)) dc_filter (
 	.clk  (clk),
 	.cen  (apu_ce & &filter_cnt),
@@ -195,18 +197,18 @@ jt49_dcrm2 #(.sw(16)) dc_filter (
 wire apu_ce;
 wire signed [15:0] sample_signed;
 
-reg [21:0] mute_cnt = 22'h3FFFFF;
+reg [20:0] mute_cnt = 21'h1FFFFF;
 
 // Pause audio to avoid loud "POP"
 always_ff @(posedge clk) begin
 	if (reset_nes)
-		mute_cnt <= 22'h3FFFFF;
+		mute_cnt <= 21'h1FFFFF;
 	else if (|mute_cnt)
 		mute_cnt <= mute_cnt - 1'b1;
 end
 
 // Filter CE impacts frequency response
-reg [3:0] filter_cnt;
+reg [1:0] filter_cnt;
 always_ff @(posedge clk) begin
 	if (apu_ce)
 		filter_cnt<= filter_cnt + 1'b1;
@@ -424,7 +426,8 @@ NES nes
    bram_addr, bram_din, bram_dout,
 	bram_write, bram_override,
 	cycle, scanline,
-	int_audio, ext_audio, apu_ce
+	int_audio, ext_audio, apu_ce,
+	scale || forced_scandoubler
 );
 
 assign SDRAM_CKE         = 1'b1;

--- a/NES.sv
+++ b/NES.sv
@@ -103,7 +103,7 @@ module emu
 assign USER_OUT = '1;
 
 assign AUDIO_S   = 1'b1;
-assign AUDIO_L   = {~sample[15], sample[14:0]};
+assign AUDIO_L   = |mute_cnt ? 16'd0 : sample_signed[15:0];
 assign AUDIO_R   = AUDIO_L;
 assign AUDIO_MIX = 0;
 
@@ -182,6 +182,36 @@ wire int_audio = ~status[31];
 wire ext_audio = 1;
 wire int_audio = 1;
 `endif
+
+// Remove DC offset and convert to signed
+jt49_dcrm2 #(.sw(16)) dc_filter (
+	.clk  (clk),
+	.cen  (apu_ce & &filter_cnt),
+	.rst  (reset_nes),
+	.din  (sample),
+	.dout (sample_signed)
+);
+
+wire apu_ce;
+wire signed [15:0] sample_signed;
+
+reg [21:0] mute_cnt = 22'h3FFFFF;
+
+// Pause audio to avoid loud "POP"
+always_ff @(posedge clk) begin
+	if (reset_nes)
+		mute_cnt <= 22'h3FFFFF;
+	else if (|mute_cnt)
+		mute_cnt <= mute_cnt - 1'b1;
+end
+
+// Filter CE impacts frequency response
+reg [3:0] filter_cnt;
+always_ff @(posedge clk) begin
+	if (apu_ce)
+		filter_cnt<= filter_cnt + 1'b1;
+end
+
 
 
 wire forced_scandoubler;
@@ -394,7 +424,7 @@ NES nes
    bram_addr, bram_din, bram_dout,
 	bram_write, bram_override,
 	cycle, scanline,
-	int_audio, ext_audio
+	int_audio, ext_audio, apu_ce
 );
 
 assign SDRAM_CKE         = 1'b1;

--- a/jt49_dcrm2.v
+++ b/jt49_dcrm2.v
@@ -1,0 +1,62 @@
+/*  This file is part of JT49.
+
+    JT49 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    JT49 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with JT49.  If not, see <http://www.gnu.org/licenses/>.
+    
+    Author: Jose Tejada Gomez. Twitter: @topapate
+    Version: 1.0
+    Date: 15-Jan-2019
+    
+    */
+
+// DC removal filter
+// input is unsigned
+// output is signed
+
+module jt49_dcrm2 #(parameter sw=8) (
+    input                clk,
+    input                cen,
+    input                rst,
+    input         [sw-1:0]  din,
+    output signed [sw-1:0]  dout
+);
+
+localparam dw=10; // widht of the decimal portion
+
+reg  signed [sw+dw:0] integ, exact, error;
+//reg  signed [2*(9+dw)-1:0] mult;
+// wire signed [sw+dw:0] plus1 = { {sw+dw{1'b0}},1'b1};
+reg  signed [sw:0] pre_dout;
+// reg signed [sw+dw:0] dout_ext;
+reg signed [sw:0] q;
+
+always @(*) begin
+    exact = integ+error;
+    q = exact[sw+dw:dw];
+    pre_dout  = { 1'b0, din } - q;
+    //dout_ext = { pre_dout, {dw{1'b0}} };    
+    //mult  = dout_ext;
+end
+
+assign dout = pre_dout[sw-1:0];
+
+always @(posedge clk)
+    if( rst ) begin
+        integ <= {sw+dw+1{1'b0}};
+        error <= {sw+dw+1{1'b0}};
+    end else if( cen ) begin
+        integ <= integ + pre_dout; //mult[sw+dw*2:dw];
+        error <= exact-{q, {dw{1'b0}}};
+    end
+
+endmodule

--- a/mappers/MMC1.sv
+++ b/mappers/MMC1.sv
@@ -34,7 +34,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;

--- a/mappers/MMC2.sv
+++ b/mappers/MMC2.sv
@@ -34,7 +34,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -194,7 +194,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire [7:0] prg_dout = 0;

--- a/mappers/MMC3.sv
+++ b/mappers/MMC3.sv
@@ -34,7 +34,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 
 wire [21:0] prg_aout, chr_aout;
@@ -215,7 +215,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire [7:0] prg_dout = 0;
@@ -545,7 +545,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire [7:0] prg_dout = 0;

--- a/mappers/MMC5.sv
+++ b/mappers/MMC5.sv
@@ -54,8 +54,8 @@ wire irq;
 wire prg_open_bus, prg_conflict, has_chr_dout;
 wire [15:0] audio;
 
-// NOTE: The volume is equal but the polarity is reversed.
-wire [16:0] audio_out = audio + audio_in;
+// NOTE: The apu volume is 75% of MMC5 and the polarity is reversed.
+wire [16:0] audio_out = audio + (audio_in[15:1] + audio_in[15:2] + audio_in[15:2]);
 
 reg [1:0] prg_mode, chr_mode;
 reg prg_protect_1, prg_protect_2;

--- a/mappers/Namco.sv
+++ b/mappers/Namco.sv
@@ -33,7 +33,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio : 16'hZ;
+assign audio_b      = enable ? audio_mix[16:1] : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -69,6 +69,8 @@ MAPN106 n106(m2[7], m2_n, clk, ~enable, prg_write, nesprg_oe, 0,
 	prgram_oe, chr_aout[18:10], ramprgaout, irq, vram_ce, exp6,
 	0, 7'b1111111, 6'b111111, flags[14], flags[16], flags[15],
 	ce, (flags[7:0]==210), flags[24:21], audio[15:5]);
+
+wire [16:0] audio_mix = audio_in + audio;
 
 assign chr_aout[21:19] = 3'b100;
 assign chr_aout[9:0] = chr_ain[9:0];

--- a/mappers/Sunsoft.sv
+++ b/mappers/Sunsoft.sv
@@ -146,7 +146,7 @@ SS5b_audio snd_5b (
 
 wire [15:0] exp_out;
 wire [15:0] exp_adj = (|exp_out[15:14] ? 16'hFFFF : {exp_out[13:0], exp_out[1:0]});
-wire [16:0] audio_mix = audio_in + ((exp_adj >> 1) + (exp_adj >> 2) + (exp_adj >> 3));
+wire [16:0] audio_mix = audio_in + exp_adj;
 
 assign audio = 16'hFFFF - audio_mix[16:1];
 
@@ -154,12 +154,12 @@ endmodule
 
 // Sunsoft 5B audio by Kitrinx
 module SS5b_audio (
-	input        clk,
-	input        ce,    // Negedge M2 (aka CPU ce)
-	input        enable,
-	input        wren,
-	input [15:0] addr_in,
-	input  [7:0] data_in,
+	input         clk,
+	input         ce,    // Negedge M2 (aka CPU ce)
+	input         enable,
+	input         wren,
+	input  [15:0] addr_in,
+	input   [7:0] data_in,
 	output [15:0] audio_out
 );
 
@@ -291,9 +291,9 @@ always_comb begin
 end
 
 assign audio_out =
-	{output_a ? ss5b_amp_lut[envelope_a] : 8'h0, 6'b0} +
-	{output_b ? ss5b_amp_lut[envelope_b] : 8'h0, 6'b0} +
-	{output_c ? ss5b_amp_lut[envelope_c] : 8'h0, 6'b0} ;
+	{output_a ? ss5b_amp_lut[envelope_a] : 8'h0, 5'b0} +
+	{output_b ? ss5b_amp_lut[envelope_b] : 8'h0, 5'b0} +
+	{output_c ? ss5b_amp_lut[envelope_c] : 8'h0, 5'b0} ;
 
 // Logarithmic amplification table in 1.5db steps
 wire [7:0] ss5b_amp_lut[0:31] = '{
@@ -304,9 +304,6 @@ wire [7:0] ss5b_amp_lut[0:31] = '{
 };
 
 endmodule
-
-
-
 
 // Mapper 190, Magic Kid GooGoo
 // Mapper 67, Sunsoft-3

--- a/mappers/Sunsoft.sv
+++ b/mappers/Sunsoft.sv
@@ -139,6 +139,11 @@ SS5b_audio snd_5b (
 	.audio_out(exp_out)
 );
 
+// Sunsoft 5B audio amplifies each channel logarithmicly before mixing. It's then mixed
+// with APU audio (reverse polarity) and then reverses the polarity of the audio again.
+// The expansion audio is much louder than APU audio, so we reduce it to 68% prior to
+// mixing.
+
 wire [15:0] exp_out;
 wire [15:0] exp_adj = (|exp_out[15:14] ? 16'hFFFF : {exp_out[13:0], exp_out[1:0]});
 wire [16:0] audio_mix = audio_in + ((exp_adj >> 1) + (exp_adj >> 2) + (exp_adj >> 3));
@@ -338,7 +343,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -479,7 +484,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;

--- a/mappers/Sunsoft.sv
+++ b/mappers/Sunsoft.sv
@@ -129,87 +129,178 @@ assign chr_allow = flags[15];
 assign chr_aout = {4'b10_00, chrout, chr_ain[9:0]};
 assign vram_ce = chr_ain[13];
 
-//Taken from Loopy's Power Pak mapper source
-//audio
-	wire [6:0] fme7_out;
-	wire [15:0] fme7_sample;
-	FME7_sound snd0(clk, ce, ~enable, prg_write, prg_ain, prg_din, fme7_out);
-	//FME7_sound snd0(m2, reset, nesprg_we, prgain, nesprgdin, fme7_out);
-	//pdm #(7) pdm_mod(clk20, fme7_out, exp6);
+SS5b_audio snd_5b (
+	.clk(clk),
+	.ce(ce),
+	.enable(enable),
+	.wren(prg_write),
+	.addr_in(prg_ain),
+	.data_in(prg_din),
+	.audio_out(exp_out)
+);
 
-//Need a better lookup table for this
-//This is just the NES APU lookup table, which is designed for 2 4-bit square waves, not 3
-ApuLookupTable lookup(clk,
-	{4'b0, fme7_out[5:1]}, //fme7_out range: 0-2D
-	{8'b0},                //No triange, noise or DMC
-	fme7_sample);
-assign audio = {fme7_sample[14:0], 1'b0};    // Double.  Volume will be slightly higher, rather than slightly lower than expected
+wire [15:0] exp_out;
+wire [15:0] exp_adj = (|exp_out[15:14] ? 16'hFFFF : {exp_out[13:0], exp_out[1:0]});
+wire [16:0] audio_mix = audio_in + ((exp_adj >> 1) + (exp_adj >> 2) + (exp_adj >> 3));
+
+assign audio = 16'hFFFF - audio_mix[16:1];
 
 endmodule
 
-//Taken from Loopy's Power Pak mapper source map45.v
-module FME7_sound(
-	input clk,
-	input ce,
-	input reset,
-	input wr,
-	input [15:0] ain,
-	input [7:0] din,
-	output [6:0] out
+// Sunsoft 5B audio by Kitrinx
+module SS5b_audio (
+	input        clk,
+	input        ce,    // Negedge M2 (aka CPU ce)
+	input        enable,
+	input        wren,
+	input [15:0] addr_in,
+	input  [7:0] data_in,
+	output [15:0] audio_out
 );
-	reg [3:0] regC;
-	reg [11:0] freq0,freq1,freq2;
-	reg [2:0] en;
-	reg [3:0] vol0,vol1,vol2;
-	reg [11:0] count0,count1,count2;
-	reg [4:0] duty0,duty1,duty2;
 
-	always@(posedge clk) begin
-		if(reset) begin
-			en <= 0;
-		end else if (ce) begin
-			if(wr) begin
-				if(ain[15:13]==3'b110)  //C000
-					regC<=din[3:0];
-				if(ain[15:13]==3'b111)  //E000
-				case(regC)
-					0:freq0[7:0]<=din;
-					1:freq0[11:8]<=din[3:0];
-					2:freq1[7:0]<=din;
-					3:freq1[11:8]<=din[3:0];
-					4:freq2[7:0]<=din;
-					5:freq2[11:8]<=din[3:0];
-					7:en<=din[2:0];
-					8:vol0<=din[3:0];
-					9:vol1<=din[3:0];
-					10:vol2<=din[3:0];
-				endcase
-			end
-			if(count0==freq0) begin
-				count0<=0;
-				duty0<=duty0+1'd1;
-			end else
-				count0<=count0+1'd1;
+reg [3:0] reg_select;
 
-			if(count1==freq1) begin
-				count1<=0;
-				duty1<=duty1+1'd1;
-			end else
-				count1<=count1+1'd1;
-			if(count2==freq2) begin
-				count2<=0;
-				duty2<=duty2+1'd1;
-			end else
-				count2<=count2+1'd1;
+// Register bank
+reg [7:0] internal[0:15];
+
+// Register abstraction to readable wires
+
+// Periods
+wire [11:0] period_a     = {internal[1][3:0], internal[0]};
+wire [11:0] period_b     = {internal[3][3:0], internal[2]};
+wire [11:0] period_c     = {internal[5][3:0], internal[4]};
+wire [4:0]  period_n     = internal[6][4:0];
+
+// Enables
+wire        tone_dis_a   = internal[7][0];
+wire        tone_dis_b   = internal[7][1];
+wire        tone_dis_c   = internal[7][2];
+wire        noise_dis_a  = internal[7][3];
+wire        noise_dis_b  = internal[7][4];
+wire        noise_dis_c  = internal[7][5];
+
+// Envelope
+// wire        env_enable_a = internal[8][4];
+ wire  [3:0] env_vol_a    = internal[8][3:0];
+// wire        env_enable_b = internal[9][4];
+ wire  [3:0] env_vol_b    = internal[9][3:0];
+// wire        env_enable_c = internal[10][4];
+ wire  [3:0] env_vol_c    = internal[10][3:0];
+// wire [15:0] env_period   = {internal[12], internal[11]};
+// wire        env_continue = internal[13][3];
+// wire        env_attack   = internal[13][2];
+// wire        env_alt      = internal[13][1];
+// wire        env_hold     = internal[13][0];
+
+reg [4:0] cycles;
+reg [11:0] tone_a_cnt, tone_b_cnt, tone_c_cnt, noise_cnt;
+
+reg [4:0] tone_a, tone_b, tone_c;
+
+wire [12:0] tone_a_next = tone_a_cnt + 1'b1;
+wire [12:0] tone_b_next = tone_b_cnt + 1'b1;
+wire [12:0] tone_c_next = tone_c_cnt + 1'b1;
+wire [12:0] noise_next = noise_cnt + 1'b1;
+
+reg [16:0] noise_lfsr = 17'h1;
+reg [5:0] envelope_a, envelope_b, envelope_c;
+
+always_ff @(posedge clk)
+if (~enable) begin
+	internal <= '{
+		8'd0, 8'd0, 8'd0, 8'd0, 8'd0, 8'd0, 8'd0, 8'd0,
+		8'd0, 8'd0, 8'd0, 8'd0, 8'd0, 8'd0, 8'd0, 8'd0};
+
+	{tone_a, tone_b, tone_c, envelope_a, envelope_b, envelope_c, cycles, noise_lfsr} <= 0;
+	{tone_a_cnt, tone_b_cnt, tone_c_cnt, noise_cnt} <= 0;
+end else if (ce) begin
+	cycles <= cycles + 1'b1;
+
+	// Write registers
+	if (wren) begin
+		if (addr_in[15:13] == 3'b110)  // C000
+			reg_select <= data_in[3:0];
+		if (addr_in[15:13] == 3'b111)  // E000
+			internal[reg_select] <= data_in;
+	end
+
+	tone_a_cnt <= tone_a_next[11:0];
+	tone_b_cnt <= tone_b_next[11:0];
+	tone_c_cnt <= tone_c_next[11:0];
+
+	if (tone_a_next >= period_a) begin
+		tone_a_cnt <= 12'd0;
+		tone_a <= tone_a + 1'b1;
+	end
+
+	if (tone_b_next >= period_b) begin
+		tone_b_cnt<= 12'd0;
+		tone_b <= tone_b + 1'b1;
+	end
+
+	if (tone_c_next >= period_c) begin
+		tone_c_cnt <= 12'd0;
+		tone_c <= tone_c + 1'b1;
+	end
+
+	// XXX: Implement modulation envelope if needed (not used in any games)
+	envelope_a <= {env_vol_a, 1'b1};
+	envelope_b <= {env_vol_b, 1'b1};
+	envelope_c <= {env_vol_c, 1'b1};
+
+	if (&cycles) begin
+		// Advance noise LFSR every 32 cycles
+		noise_cnt <= noise_next[11:0];
+
+		if (noise_next >= period_n) begin
+			noise_lfsr <= {noise_lfsr[15:0], noise_lfsr[16] ^ noise_lfsr[13]};
+			noise_cnt <= 12'd0;
 		end
 	end
 
-	wire [3:0] ch0={4{~en[0] & duty0[4]}} & vol0;
-	wire [3:0] ch1={4{~en[1] & duty1[4]}} & vol1;
-	wire [3:0] ch2={4{~en[2] & duty2[4]}} & vol2;
-	assign out=ch0+ch1+ch2;
+end
+
+wire output_a, output_b, output_c;
+
+always_comb begin
+	case ({tone_dis_a, noise_dis_a})
+		2'b00: output_a = noise_lfsr[0] & tone_a[4];
+		2'b01: output_a = tone_a[4];
+		2'b10: output_a = noise_lfsr[0];
+		2'b11: output_a = 1'b0;
+	endcase
+
+	case ({tone_dis_b, noise_dis_b})
+		2'b00: output_b = noise_lfsr[0] & tone_b[4];
+		2'b01: output_b = tone_b[4];
+		2'b10: output_b = noise_lfsr[0];
+		2'b11: output_b = 1'b0;
+	endcase
+
+	case ({tone_dis_c, noise_dis_c})
+		2'b00: output_c = noise_lfsr[0] & tone_c[4];
+		2'b01: output_c = tone_c[4];
+		2'b10: output_c = noise_lfsr[0];
+		2'b11: output_c = 1'b0;
+	endcase
+end
+
+assign audio_out =
+	{output_a ? ss5b_amp_lut[envelope_a] : 8'h0, 6'b0} +
+	{output_b ? ss5b_amp_lut[envelope_b] : 8'h0, 6'b0} +
+	{output_c ? ss5b_amp_lut[envelope_c] : 8'h0, 6'b0} ;
+
+// Logarithmic amplification table in 1.5db steps
+wire [7:0] ss5b_amp_lut[0:31] = '{
+	8'd0,  8'd0,  8'd1,  8'd1,  8'd1,   8'd1,   8'd2,   8'd2,
+	8'd3,  8'd3,  8'd4,  8'd5,  8'd6,   8'd7,   8'd9,   8'd11,
+	8'd13, 8'd15, 8'd18, 8'd22, 8'd26,  8'd31,  8'd37,  8'd44,
+	8'd53, 8'd63, 8'd74, 8'd89, 8'd105, 8'd125, 8'd149, 8'd177
+};
 
 endmodule
+
+
 
 
 // Mapper 190, Magic Kid GooGoo

--- a/mappers/generic.sv
+++ b/mappers/generic.sv
@@ -34,7 +34,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -87,7 +87,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -149,7 +149,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -235,7 +235,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -324,7 +324,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -406,7 +406,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -488,7 +488,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -561,7 +561,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -648,7 +648,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -717,7 +717,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -823,7 +823,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -893,7 +893,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;

--- a/mappers/misc.sv
+++ b/mappers/misc.sv
@@ -34,7 +34,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -142,7 +142,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -337,7 +337,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -526,7 +526,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -645,7 +645,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -751,7 +751,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? irq : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -891,7 +891,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -963,7 +963,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -1015,7 +1015,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -1086,7 +1086,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;
@@ -1165,7 +1165,7 @@ assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
 assign vram_ce_b    = enable ? vram_ce : 1'hZ;
 assign irq_b        = enable ? 1'b0 : 1'hZ;
 assign flags_out_b  = enable ? flags_out : 16'hZ;
-assign audio_b      = enable ? audio_in : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
 
 wire [21:0] prg_aout, chr_aout;
 wire prg_allow;

--- a/nes.v
+++ b/nes.v
@@ -152,7 +152,8 @@ module NES(input clk, input reset, input ce,
            output [8:0] cycle,
            output [8:0] scanline,
            input int_audio,
-           input ext_audio
+           input ext_audio,
+           output apu_ce_o
            );
   reg [7:0] from_data_bus;
   wire [7:0] cpu_dout;
@@ -353,6 +354,8 @@ module NES(input clk, input reset, input ce,
     // User input
     .fds_swap          (fds_swap)                 // Used to trigger FDS disk changes
   );
+
+  assign apu_ce_o = apu_ce;
 
   assign chr_to_ppu = has_chr_from_ppu_mapper ? chr_from_ppu_mapper : memory_din_ppu;
                              

--- a/nes.v
+++ b/nes.v
@@ -153,7 +153,8 @@ module NES(input clk, input reset, input ce,
            output [8:0] scanline,
            input int_audio,
            input ext_audio,
-           output apu_ce_o
+           output apu_ce_o,
+           input scandouble
            );
   reg [7:0] from_data_bus;
   wire [7:0] cpu_dout;
@@ -278,7 +279,7 @@ module NES(input clk, input reset, input ce,
           ppu_cs && mr_ppu, ppu_cs && mw_ppu,
           nmi,
           chr_read, chr_write, chr_addr, chr_to_ppu, chr_from_ppu,
-          scanline, cycle, mapper_ppu_flags);
+          scanline, cycle, mapper_ppu_flags, scandouble);
 
   // -- Memory mapping logic
   wire [15:0] prg_addr = addr;

--- a/nes.v
+++ b/nes.v
@@ -291,16 +291,31 @@ module NES(input clk, input reset, input ce,
   wire mapper_irq;
   wire has_chr_from_ppu_mapper;
   wire [15:0] sample_ext;
-  reg [16:0] sample_sum;
-  assign sample = sample_sum[16:1]; //loss of 1 bit of resolution.  Add control for when no external audio to boost back up?
+  //assign sample = {int_audio, ext_audio}sample_sum[16:1]; //loss of 1 bit of resolution.  Add control for when no external audio to boost back up?
   
+  assign sample = sample_a;
+  reg [15:0] sample_a;
+
+  always @* begin
+    case (audio_en)
+      0: sample_a = 16'd0;
+      1: sample_a = sample_ext;
+      2: sample_a = sample_inverted;
+      3: sample_a = sample_ext;
+    endcase
+  end
+
+  wire [15:0] sample_inverted = 16'hFFFF - sample_apu;
+  wire [1:0] audio_en = {int_audio, ext_audio};
+  wire [15:0] audio_mappers = (audio_en == 2'd1) ? 16'd0 : sample_inverted;
+
   cart_top multi_mapper (
     // FPGA specific
     .clk               (clk),
     .reset             (reset),
     .flags             (mapper_flags),            // iNES header data (use 0 while loading)
     // Cart pins (slightly abstracted)
-    .ce                (cart_ce),        // M2 (held in high impedance during reset)
+    .ce                (cart_ce & ~reset),        // M2 (held in high impedance during reset)
     .prg_ain           (prg_addr),                // CPU Address in (a15 abstracted from ROMSEL)
     .prg_read          (prg_read),                // CPU RnW split
     .prg_write         (prg_write),               // CPU RnW split
@@ -314,7 +329,7 @@ module NES(input clk, input reset, input ce,
     .vram_a10          (vram_a10),                // CIRAM a10 line
     .vram_ce           (vram_ce),                 // CIRAM chip enable
     .irq               (mapper_irq),              // IRQ (inverted, active high)
-    .audio_in          (16'h0),                   // Amplified and inverted APU audio
+    .audio_in          (audio_mappers),           // Amplified and inverted APU audio
     .audio             (sample_ext),              // Mixed audio output from cart
     // SDRAM Communication
     .prg_aout          (prg_linaddr),             // SDRAM adjusted PRG RAM address
@@ -351,14 +366,6 @@ module NES(input clk, input reset, input ce,
       mapper_irq_delayed <= mapper_irq;
     if (apu_ce)
       apu_irq_delayed <= apu_irq;
-    if (ce | apu_ce) begin
-      case ({int_audio, ext_audio})
-      0: sample_sum <= 17'b0;
-      1: sample_sum <= {1'b0,sample_ext};
-      2: sample_sum <= {1'b0,sample_apu};
-      3: sample_sum <= {1'b0,sample_ext} + {1'b0,sample_apu};
-      endcase
-    end
   end
    
   // -- Multiplexes CPU and PPU accesses into one single RAM


### PR DESCRIPTION
Changes the following:

-Audio is now mixed in the mappers as it should be
-Corrected the polarity on audio
-Added a high pass filter from jt49. This fixes the extreme bias that was present in digital audio and corrects audio compatibility issues with Elgato capture carts and some tvs.
-Add a mute during reset to avoid loud "POP" when games start.
-Use signed audio out to double maximum volume
-Fix clock on MMC5 mapper. (Just Breed) so audio is now correct.
-Mix MMC5 at correct level
-Change amplification on VRC6 to be linear rather than logarithmic, as the original was
-Fix levels of VRC6 audio
-Rewrite Sunsoft 5B audio mapper, now correct sound in Gimmick!
-Adjusted VRC7 levels.

-Added a temporary fix for PPU "jitter" causing problems with scandoubler. I will fix this better when I figured out a good way to attack it.

I tested every mapper after all of these changes and everything seems to be working at least as well as it was before. James-F and some others also helped verify the levels.