### PR TITLE
enable color emphasis bits from PPU

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -427,8 +427,10 @@ NES nes
 	bram_write, bram_override,
 	cycle, scanline,
 	int_audio, ext_audio, apu_ce,
-	scale || forced_scandoubler
+	scale || forced_scandoubler, emphasis
 );
+
+wire [2:0] emphasis;
 
 assign SDRAM_CKE         = 1'b1;
 
@@ -537,6 +539,7 @@ video video
 	.scale(scale),
 	.hide_overscan(hide_overscan),
 	.palette(palette2_osd),
+	.emphasis(emphasis),
 
 	.ce_pix(CE_PIXEL)
 );

--- a/nes.v
+++ b/nes.v
@@ -154,7 +154,8 @@ module NES(input clk, input reset, input ce,
            input int_audio,
            input ext_audio,
            output apu_ce_o,
-           input scandouble
+           input scandouble,
+           output [2:0] emphasis
            );
   reg [7:0] from_data_bus;
   wire [7:0] cpu_dout;
@@ -279,7 +280,7 @@ module NES(input clk, input reset, input ce,
           ppu_cs && mr_ppu, ppu_cs && mw_ppu,
           nmi,
           chr_read, chr_write, chr_addr, chr_to_ppu, chr_from_ppu,
-          scanline, cycle, mapper_ppu_flags, scandouble);
+          scanline, cycle, mapper_ppu_flags, scandouble, emphasis);
 
   // -- Memory mapping logic
   wire [15:0] prg_addr = addr;

--- a/ppu.sv
+++ b/ppu.sv
@@ -507,7 +507,8 @@ module PPU(input clk, input ce, input reset,   // input clock  21.48 MHz / 4. 1 
            output [8:0] scanline,
            output [8:0] cycle,
            output [19:0] mapper_ppu_flags,
-           input scandouble); // This should be removed ASAP. Disabling alternate lines wrecks NMI sync
+           input scandouble,
+           output [2:0] emphasis); // This should be removed ASAP. Disabling alternate lines wrecks NMI sync
   // These are stored in control register 0
   reg obj_patt; // Object pattern table
   reg bg_patt;  // Background pattern table
@@ -519,7 +520,7 @@ module PPU(input clk, input ce, input reset,   // input clock  21.48 MHz / 4. 1 
   reg object_clip;        // 0: Left side 8 pixels object clipping
   reg enable_playfield;   // Enable playfield display
   reg enable_objects;     // Enable objects display
-  //reg [2:0] color_intensity; // Color intensity
+  reg [2:0] color_intensity; // Color intensity
   
   initial begin
     obj_patt = 0;
@@ -531,7 +532,7 @@ module PPU(input clk, input ce, input reset,   // input clock  21.48 MHz / 4. 1 
     object_clip = 0;
     enable_playfield = 0;
     enable_objects = 0;
-    //color_intensity = 0;
+    color_intensity = 0;
   end
   
   reg nmi_occured;         // True if NMI has occured but not cleared.
@@ -550,6 +551,7 @@ module PPU(input clk, input ce, input reset,   // input clock  21.48 MHz / 4. 1 
   ClockGen clock(clk, ce, reset, is_rendering, scanline, cycle, is_in_vblank, end_of_line, at_last_cycle_group,
                  exiting_vblank, entering_vblank, is_pre_render_line, scandouble);
   
+  assign emphasis = color_intensity;
   
   // The loopy module handles updating of the loopy address
   wire [14:0] loopy;
@@ -686,7 +688,7 @@ module PPU(input clk, input ce, input reset,   // input clock  21.48 MHz / 4. 1 
         object_clip <= din[2];
         enable_playfield <= din[3];
         enable_objects <= din[4];
-        //color_intensity <= din[7:5];
+        color_intensity <= din[7:5];
         //if (!din[3] && scanline == 59) $write("Disabling playfield at cycle %d\n", cycle);
       end
       endcase

--- a/video.sv
+++ b/video.sv
@@ -11,6 +11,7 @@ module video
 	input  [2:0] scale,
 	input        hide_overscan,
 	input  [3:0] palette,
+	input  [2:0] emphasis,
 
 	output       ce_pix,
 
@@ -275,9 +276,26 @@ always @(posedge clk) begin
 	end
 end
 
-wire  [4:0] vga_r = pixel[4:0];
-wire  [4:0] vga_g = pixel[9:5];
-wire  [4:0] vga_b = pixel[14:10];
+wire dark_r, dark_g, dark_b;
+// bits are in order {B, G, R} color emphasis
+always_comb begin
+	{dark_r, dark_g, dark_b} = 3'b000;
+
+	if (~&color[3:0] & |emphasis) begin
+		if (~&emphasis) begin
+			dark_r = ~emphasis[2];
+			dark_g = ~emphasis[1];
+			dark_b = ~emphasis[0];
+		end else begin
+			{dark_r, dark_g, dark_b} = 3'b111;
+		end
+	end
+
+end
+
+wire  [4:0] vga_r = dark_r ? pixel[4:1] + pixel[4:2] : pixel[4:0];
+wire  [4:0] vga_g = dark_g ? pixel[9:6] + pixel[9:7] : pixel[9:5];
+wire  [4:0] vga_b = dark_b ? pixel[14:11] + pixel[14:12] : pixel[14:10];
 
 video_mixer #(260, 0) video_mixer
 (


### PR DESCRIPTION
These bits de-emphasize some or all of the colors. You can see them used when entering a battle in Final Fantasy 1 or pausing the game in Super Spy Hunter.

https://wiki.nesdev.com/w/index.php/Colour-emphasis_games