### PR TITLE
autosaving on OSD

### DIFF
--- a/nes.v
+++ b/nes.v
@@ -155,7 +155,8 @@ module NES(input clk, input reset, input ce,
            input ext_audio,
            output apu_ce_o,
            input scandouble,
-           output [2:0] emphasis
+           output [2:0] emphasis,
+           output save_written
            );
   reg [7:0] from_data_bus;
   wire [7:0] cpu_dout;
@@ -294,8 +295,9 @@ module NES(input clk, input reset, input ce,
   wire mapper_irq;
   wire has_chr_from_ppu_mapper;
   wire [15:0] sample_ext;
-  //assign sample = {int_audio, ext_audio}sample_sum[16:1]; //loss of 1 bit of resolution.  Add control for when no external audio to boost back up?
-  
+
+  assign save_written = (prg_addr[15:13] == 3'b011 && prg_write) | bram_write;
+
   assign sample = sample_a;
   reg [15:0] sample_a;
 


### PR DESCRIPTION
NES is a little harder than gameboy and genesis, since those two don't use backup ram for work space.

For NES I do this:
1) check iNES header for "has battery backed ram" flag
2) check prg ram 6000 - 7FFF or eeprom for writes

if both of these are true, save will be written exactly once next time OSD is opened, if the Autosave option is enabled.

This will get a lot of false positives in games like Adventure of Link or Final Fantasy where the prg ram is written all the time, however, it will still work to save the user's saves when the OSD opens. There might just be some extra writes that aren't needed. Since the OSD doesn't open that much, this still won't cause any appreciable wear to the SD card.

I enable the USER LED only when Autosave is on. It will stay on a lot in some games because of what I said above, but I feel it's important for the user to know if their save will be written or not. If the header is wrong, the user can still use manual save options.
