### PR TITLE
zapper tweaks

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -580,7 +580,7 @@ wire [2:0] scale = status[3:1];
 wire [2:0] sl = scale ? scale - 1'd1 : 3'd0;
 assign VGA_SL = sl[1:0];
 
-wire reticule;
+wire [1:0] reticule;
 wire hold_reset;
 
 video video

--- a/video.sv
+++ b/video.sv
@@ -13,7 +13,7 @@ module video
 	input        hide_overscan,
 	input  [3:0] palette,
 	input  [2:0] emphasis,
-	input        reticule,
+	input  [1:0] reticule,
 
 	output       ce_pix,
 	output   reg hold_reset,
@@ -27,7 +27,7 @@ module video
 );
 
 reg pix_ce, pix_ce_n;
-wire [5:0] color_ef = reticule ? 6'h16 : is_padding ? 6'd63 : color;
+wire [5:0] color_ef = reticule[0] ? (reticule[1] ? 6'h21 : 6'h15) : is_padding ? 6'd63 : color;
 
 always @(negedge clk) begin
 	reg [1:0] cnt = 0;


### PR DESCRIPTION
-Target cursor now turns blue at edge of screen, to indicate you are shooting off the screen (some games require this)

-Target is now wider so games like Operation Wolf work better

-Mouse button and joystick button are trigger in both Mouse and Joystick mode now, to make mapping gun-like devices easier