### PR TITLE
Fix Mapper 48 IRQs

### DIFF
--- a/mappers/MMC3.sv
+++ b/mappers/MMC3.sv
@@ -334,8 +334,8 @@ end else if (ce) begin
 
 				5'b10_00_1: irq_latch <= prg_din ^ 8'hFF;              // IRQ latch ($C000-$DFFC)
 				5'b10_01_1: irq_reload <= 1;                           // IRQ reload ($C001-$DFFD)
-				5'b10_10_1: begin irq_enable <= 0; irq_reg[0] <= 0; end// IRQ disable ($C002-$DFFE)
-				5'b10_11_1: irq_enable <= 1;                           // IRQ enable ($C003-$DFFF)
+				5'b10_10_1: irq_enable <= 1;                           // IRQ enable ($C002-$DFFE)
+				5'b10_11_1: begin irq_enable <= 0; irq_reg[0] <= 0; end// IRQ disable ($C003-$DFFF)
 
 				5'b11_00_1: mirroring <= !prg_din[6];  // Mirroring
 			endcase


### PR DESCRIPTION
Mapper 48 enable/disable registers are in reverse order compared to MMC3.
--Fixes Bubble Bobble 2 and Captain Saver.

There are still some slight graphical errors, likely related to irq timing, but I believe that requires better documentation of the hardware to fix.