### PR TITLE
PAL and Dendy support.

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -127,6 +127,12 @@ assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
 
 `define DEBUG_AUDIO
 
+// Status Bit Map:
+// 0         1         2         3 
+// 01234567890123456789012345678901
+// 0123456789ABCDEFGHIJKLMNOPQRSTUV
+//  XXXXXXXXXX XXXXXXXXXXXXX     XX
+
 `include "build_id.v"
 parameter CONF_STR = {
 	"NES;;",
@@ -134,6 +140,8 @@ parameter CONF_STR = {
 	"FS,NES;",
 	"FS,FDS;",
 	"H1F,BIN,Load FDS BIOS;",
+	"-;",
+	"ONO,System Type,NTSC,PAL,Dendy;",
 	"-;",
 	"OG,Disk Swap,Auto,FDS button;",	
 	"O5,Invert Mirroring,Off,On;",
@@ -443,6 +451,7 @@ wire lightgun_en = |status[19:18];
 NES nes (
 	.clk             (clk),
 	.reset_nes       (reset_nes),
+	.sys_type        (status[24:23]),
 	.nes_div         (nes_ce),
 	.mapper_flags    (downloading ? 32'd0 : mapper_flags),
 	.gg              (status[20]),

--- a/NES.sv
+++ b/NES.sv
@@ -114,8 +114,8 @@ assign LED_USER  = downloading | (loader_fail & led_blink) | (bk_state != S_IDLE
 assign LED_DISK  = 0;
 assign LED_POWER = 0;
 
-assign VIDEO_ARX = status[8] ? 8'd16 : (status[4] ? 8'd64 : 8'd128);
-assign VIDEO_ARY = status[8] ? 8'd9  : (status[4] ? 8'd49 : 8'd105);
+assign VIDEO_ARX = status[8] ? 8'd16 : (hide_overscan ? 8'd64 : 8'd128);
+assign VIDEO_ARY = status[8] ? 8'd9  : (hide_overscan ? 8'd49 : 8'd105);
 
 assign CLK_VIDEO = clk;
 
@@ -180,7 +180,7 @@ wire [31:0] status;
 
 wire arm_reset = status[0];
 wire mirroring_osd = status[5];
-wire hide_overscan = status[4];
+wire hide_overscan = status[4] && ~|status[24:23];
 wire [3:0] palette2_osd = status[15:12];
 wire joy_swap = status[9];
 wire fds_swap_invert = status[16];

--- a/apu.sv
+++ b/apu.sv
@@ -432,6 +432,7 @@ module DmcChan(input MMC5,
                output [15:0] DmaAddr,  // Address DMC wants to read
                input [7:0] DmaData,    // Input data to DMC from memory.
                output Irq,
+               input PAL,
                output IsDmcActive);
   reg IrqEnable;
   reg IrqActive;
@@ -462,6 +463,13 @@ module DmcChan(input MMC5,
 		286, 254, 226, 214,
 		190, 160, 142, 128,
 		106, 84, 72, 54
+  };
+
+  wire [8:0] NewPeriodPAL[16] = '{
+    398, 354, 316, 298,
+    276, 236, 210, 198,
+    176, 148, 132, 118,
+    98,  78,  66,  50
   };
 
   // Shift register initially loaded with 07
@@ -521,7 +529,7 @@ module DmcChan(input MMC5,
 
       Cycles <= Cycles - 1'd1;
       if (Cycles == 1) begin
-        Cycles <= NewPeriod[Freq];
+        Cycles <= PAL ? NewPeriodPAL[Freq] : NewPeriod[Freq];
         if (HasShiftReg) begin
           if (ShiftReg[0]) begin
             Dac[6:1] <= (Dac[6:1] != 6'b111111) ? Dac[6:1] + 6'b000001 : Dac[6:1];
@@ -558,6 +566,7 @@ endmodule
 
 module APU(input MMC5,
            input clk, input ce, input reset,
+           input PAL,
            input [4:0] ADDR,  // APU Address Line
            input [7:0] DIN,   // Data to APU
            output [7:0] DOUT, // Data from APU
@@ -613,7 +622,7 @@ SquareChan	 Sq1(MMC5, clk, ce, reset, 1'b0, ADDR[1:0], DIN, ApuMW0, ClkL, ClkE, 
 SquareChan   Sq2(MMC5, clk, ce, reset, 1'b1, ADDR[1:0], DIN, ApuMW1, ClkL, ClkE, odd_or_even, Enabled[1], LenCtr_In, Sq2Sample, Sq2NonZero);
 TriangleChan Tri(clk, ce, reset, ADDR[1:0], DIN, ApuMW2, ClkL, ClkE, Enabled[2], LenCtr_In, TriSample, TriNonZero);
 NoiseChan    Noi(clk, ce, reset, ADDR[1:0], DIN, ApuMW3, ClkL, ClkE, Enabled[3], LenCtr_In, NoiSample, NoiNonZero);
-DmcChan      Dmc(MMC5, clk, ce, reset, odd_or_even, ADDR[2:0], DIN, ApuMW4, DmcSample, DmaReq, DmaAck, DmaAddr, DmaData, DmcIrq, IsDmcActive);
+DmcChan      Dmc(MMC5, clk, ce, reset, odd_or_even, ADDR[2:0], DIN, ApuMW4, DmcSample, DmaReq, DmaAck, DmaAddr, DmaData, DmcIrq, PAL, IsDmcActive);
 
 // Reading this register clears the frame interrupt flag (but not the DMC interrupt flag).
 // If an interrupt flag was set at the same moment of the read, it will read back as 1 but it will not be cleared.
@@ -637,6 +646,9 @@ reg [7:0] last_4017 = 0;
 reg [2:0] delayed_clear;
 reg delayed_interrupt;
 wire set_irq = ((Cycles == 29828) || (Cycles == 29829) || delayed_interrupt) && ~DisableFrameInterrupt && ~FrameSeqMode;
+
+int cyc_ntsc[7] = '{8312, 16626, 24938, 33251, 33252, 41564, 41565};
+int cyc_pal[7]  = '{7456, 14912, 22370, 29828, 29829, 37280, 37281};
 
 always @(posedge clk) if (reset) begin
   delayed_interrupt <= 0;
@@ -674,27 +686,27 @@ end else if (ce) begin
   ClkE <= 0;
   ClkL <= 0;
   delayed_interrupt <= 1'b0;
-  if (Cycles == 7456) begin
+  if (Cycles == (PAL ? cyc_pal[0] : cyc_ntsc[0])) begin
     ClkE <= 1;
-  end else if (Cycles == 14912) begin
+  end else if (Cycles == (PAL ? cyc_pal[1] : cyc_ntsc[1])) begin
     ClkE <= 1;
     ClkL <= 1;
-  end else if (Cycles == 22370) begin
+  end else if (Cycles == (PAL ? cyc_pal[2] : cyc_ntsc[2])) begin
     ClkE <= 1;
-  end else if (Cycles == 29828) begin
+  end else if (Cycles == (PAL ? cyc_pal[3] : cyc_ntsc[3])) begin
     if (!FrameSeqMode) begin
       ClkE <= 1;
       ClkL <= 1;
     end
-  end else if (Cycles == 29829) begin
+  end else if (Cycles == (PAL ? cyc_pal[4] : cyc_ntsc[4])) begin
     if (!FrameSeqMode) begin
       delayed_interrupt <= 1'b1;
       Cycles <= 0;
     end
-  end else if (Cycles == 37280) begin
+  end else if (Cycles == (PAL ? cyc_pal[5] : cyc_ntsc[5])) begin
     ClkE <= 1;
     ClkL <= 1;
-  end else if (Cycles == 37281) begin
+  end else if (Cycles == (PAL ? cyc_pal[6] : cyc_ntsc[6])) begin
     Cycles <= 0;
   end
   


### PR DESCRIPTION
AKA "I'm not your buddy, PAL"

PAL mode will be at the wrong speed (pitch in sound is off, etc) without a PLL reconfigure. The correct frequencies are: NTSC/Dendy: 21.477272, PAL: 21.2813696. Even though they seem close, the music pitch will be notably off unless those frequencies are used.

Otherwise, most PAL titles run correctly, including Elite. Some mappers were made without PAL in mind and will need to be looked at (Sunsoft 5b in particular).

edit: nevermind, gimmick works fine. I guess I fixed it in my last round of cleanups and tweaks.
