### PR TITLE
Fix VRC7 OPLL tremulo (Amplitude Modulator)

### DIFF
--- a/SOUND/OPLL/VM2413/envelopegenerator.vhd
+++ b/SOUND/OPLL/VM2413/envelopegenerator.vhd
@@ -200,10 +200,10 @@ begin
                     if am ='1' then
                         if (amphase(amphase'high) = '0') then
                             -- è„ÇËÇÃèÍçá
-                            egtmp := egtmp + ("00000"&(amphase(amphase'high-1 downto amphase'high-4-6)-'1'));
+                            egtmp := egtmp + ("00000"&(amphase(amphase'high-1 downto amphase'high-4-6)-"0001000000"));
                         else
                             -- â∫ÇËÇÃèÍçá
-                            egtmp := egtmp + ("00000"&("1111"-amphase(amphase'high-1 downto amphase'high-4-6)));
+                            egtmp := egtmp + ("00000"&("1111000000"-amphase(amphase'high-1 downto amphase'high-4-6)));
                         end if;
                     end if;
 


### PR DESCRIPTION
It looks like the amplitude modulator phase was originally calculated as 4 bits (plus sign).  This was increased by 6 bits of precision, but the corresponding constants were not adjusted to match.
Improved mixing volumes by Kitrinx (with adjustment from James-F2).