### PR TITLE
align video clock to system clock

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -146,7 +146,7 @@ parameter CONF_STR = {
 	"O5,Invert Mirroring,Off,On;",
 	"-;",
 	"C,Cheats;",
-	"H20K,Cheats Enabled,On,Off;",
+	"H2OK,Cheats Enabled,On,Off;",
 	"-;",
 	"D0R6,Load Backup RAM;",
 	"D0R7,Save Backup RAM;",
@@ -507,14 +507,14 @@ always @(posedge clk) begin
 end
  
 wire reset_nes = 
-	~init_reset_n || 
-	buttons[1] || 
-	arm_reset || 
-	download_reset || 
-	loader_fail || 
-	bk_loading || 
-	bk_loading_req || 
-	hold_reset ||
+	~init_reset_n  ||
+	buttons[1]     ||
+	arm_reset      ||
+	download_reset ||
+	loader_fail    ||
+	bk_loading     ||
+	bk_loading_req ||
+	hold_reset     ||
 	(old_sys_type != status[24:23]);
 
 reg [1:0] old_sys_type;

--- a/NES.sv
+++ b/NES.sv
@@ -401,7 +401,7 @@ end
 
 wire fds_eject = swap_delay[2] | fds_swap_invert ? fds_btn : (clkcount[21] | fds_btn);
 
-reg [2:0] nes_ce;
+reg [1:0] nes_ce;
 
 reg [7:0] mic_cnt;
 
@@ -506,7 +506,19 @@ always @(posedge clk) begin
 	end;
 end
  
-wire reset_nes = ~init_reset_n || buttons[1] || arm_reset || download_reset || loader_fail || bk_loading || bk_loading_req || hold_reset;
+wire reset_nes = 
+	~init_reset_n || 
+	buttons[1] || 
+	arm_reset || 
+	download_reset || 
+	loader_fail || 
+	bk_loading || 
+	bk_loading_req || 
+	hold_reset ||
+	(old_sys_type != status[24:23]);
+
+reg [1:0] old_sys_type;
+always @(posedge clk) old_sys_type <= status[24:23];
 
 wire [17:0] bram_addr;
 wire [7:0] bram_din;
@@ -524,7 +536,7 @@ wire lightgun_en = |status[19:18];
 NES nes (
 	.ex_sprites      (status[25]),
 	.clk             (clk),
-	.reset_nes       (reset_nes),
+	.reset           (reset_nes),
 	.sys_type        (status[24:23]),
 	.nes_div         (nes_ce),
 	.mapper_flags    (downloading ? 32'd0 : mapper_flags),
@@ -741,6 +753,7 @@ video video
 	.*,
 	.clk(clk),
 	.reset(reset_nes),
+	.cnt(nes_ce),
 	.hold_reset(hold_reset),
 	.count_v(scanline),
 	.count_h(cycle),

--- a/nes.v
+++ b/nes.v
@@ -71,7 +71,7 @@ endmodule
 
 module NES(
 	input         clk,
-	input         reset_nes,
+	input         reset,
 	input   [1:0] sys_type,
 	output  [1:0] nes_div,
 	input  [31:0] mapper_flags,
@@ -154,8 +154,6 @@ module NES(
 
 assign nes_div = div_sys;
 assign apu_ce = cpu_ce;
-
-wire reset = reset_nes | (last_sys_type != sys_type);
 
 wire [7:0] from_data_bus;
 wire [7:0] cpu_dout;

--- a/ppu.sv
+++ b/ppu.sv
@@ -181,10 +181,10 @@ assign at_last_cycle_group = (cycle[8:3] == 42);
 
 // For NTSC only, the *last* cycle of odd frames is skipped.
 // In Visual 2C02, the counter starts at zero and flips at scanline 256.
-assign short_frame = end_of_line & skip_pixel && skip_en;
+assign short_frame = end_of_line & skip_pixel;
 
-wire skip_pixel = is_pre_render && ~even_frame_toggle && is_rendering;
-assign end_of_line = at_last_cycle_group && (cycle[3:0] == (skip_pixel && skip_en ? 3 : 4));
+wire skip_pixel = is_pre_render && ~even_frame_toggle && is_rendering && skip_en;
+assign end_of_line = at_last_cycle_group && (cycle[3:0] == (skip_pixel ? 3 : 4));
 
 // Confimed with Visual 2C02
 // All vblank clocked registers should have changed and be readable by cycle 1 of 241/261
@@ -217,7 +217,7 @@ end else if (ce && end_of_line) begin
 	is_pre_render <= (scanline == vblank_end_sl);
 
 	if (scanline == 255)
-		even_frame_toggle <= skip_en ? ~even_frame_toggle : 1'b0;
+		even_frame_toggle <= ~even_frame_toggle;
 end
 
 endmodule // ClockGen

--- a/video.sv
+++ b/video.sv
@@ -5,6 +5,7 @@ module video
 (
 	input        clk,
 	input        reset,
+	input  [1:0] cnt,
 	input  [5:0] color,
 	input  [8:0] count_h,
 	input  [8:0] count_v,
@@ -31,8 +32,6 @@ reg pix_ce, pix_ce_n;
 wire [5:0] color_ef = reticle[0] ? (reticle[1] ? 6'h21 : 6'h15) : is_padding ? 6'd63 : color;
 
 always @(negedge clk) begin
-	reg [1:0] cnt = 0;
-	cnt <= cnt + 1'd1;
 	pix_ce   <= ~cnt[1] & ~cnt[0];
 	pix_ce_n <=  cnt[1] & ~cnt[0];
 end


### PR DESCRIPTION
correctly fixes the hsync issue. the CE counter in video.sv was getting out of aligment. Also reset at top level for more robust behavior.