### PR TITLE
Fix Sunsoft 5B (mapper 69) Cart RAM issue caused by 2MB PRG size change.

### DIFF
--- a/mappers/Sunsoft.sv
+++ b/mappers/Sunsoft.sv
@@ -123,7 +123,7 @@ always begin
 end
 
 wire ram_cs = (prg_ain[15] == 0 && ram_select);
-assign prg_aout = {1'b0, ram_cs, 2'b00, prgout[4:0], prg_ain[12:0]};
+assign prg_aout = {ram_cs ? 4'b1111 : 4'b0000, prgout[4:0], prg_ain[12:0]};
 assign prg_allow = ram_cs ? ram_enable : !prg_write;
 assign chr_allow = flags[15];
 assign chr_aout = {4'b10_00, chrout, chr_ain[9:0]};


### PR DESCRIPTION
Cart RAM is mapped to high four address bits 1111.  Now that 2MB PRG sizes are allowed, this should be enforced in all mappers.
--Fixes Batman Return of the Joker