### PR TITLE
Timing fixes

### DIFF
--- a/NES.qsf
+++ b/NES.qsf
@@ -13,7 +13,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
 set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.0.0 Standard Edition"
 
 set_global_assignment -name GENERATE_RBF_FILE ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files

--- a/NES.sv
+++ b/NES.sv
@@ -428,8 +428,8 @@ assign USER_OUT[5] = 1'b1;
 always_comb begin
 	if (raw_serial) begin
 		USER_OUT[0] = joypad_strobe;
-		USER_OUT[1] = joy_swap ? ~joypad_clock[1] : ~joypad_clock[0];
-		joy_data = {~USER_IN[4], ~USER_IN[2], joy_swap ? ~USER_IN[5] : joypad_bits2[0], joy_swap ? joypad_bits[0] : ~USER_IN[5]};
+		USER_OUT[1] = ~joy_swap ? ~joypad_clock[1] : ~joypad_clock[0];
+		joy_data = {~USER_IN[4], ~USER_IN[2], ~joy_swap ? ~USER_IN[5] : joypad_bits2[0], ~joy_swap ? joypad_bits[0] : ~USER_IN[5]};
 	end else begin
 		USER_OUT[0] = 1'b1;
 		USER_OUT[1] = 1'b1;
@@ -587,7 +587,7 @@ wire lightgun_en = |status[19:18];
 
 NES nes (
 	.clk             (clk),
-	.reset           (reset_nes),
+	.reset_nes       (reset_nes),
 	.sys_type        (status[24:23]),
 	.nes_div         (nes_ce),
 	.mapper_flags    (downloading ? 32'd0 : mapper_flags),

--- a/mappers/VRC.sv
+++ b/mappers/VRC.sv
@@ -504,14 +504,13 @@ reg [5:0] prgbank8;
 reg [5:0] prgbankA;
 reg [5:0] prgbankC;
 wire prg_ain43 = prg_ain[4] ^ prg_ain[3];
-reg ramw, soff;
+reg ramw;
 
 always@(posedge clk) begin
 	if (~enable) begin
-		soff <= 1'b0;
 		{chrbank0, chrbank1, chrbank2, chrbank3, chrbank4, chrbank5, chrbank6, chrbank7} <= 0;
 		{prgbank8, prgbankA, prgbankC} <= 0;
-		{ramw, soff} <= 0;
+		ramw <= 0;
 	end else if(ce && prg_write) begin
 		casex({prg_ain[15:12],prg_ain43})
 			5'b10000:prgbank8<=prg_din[5:0]; //8000
@@ -525,7 +524,7 @@ always@(posedge clk) begin
 			5'b11001:chrbank5<=prg_din;      //C008/10
 			5'b11010:chrbank6<=prg_din;      //D000
 			5'b11011:chrbank7<=prg_din;      //D008/10
-			5'b11100:{ramw,soff,mirror}<={prg_din[7:6],prg_din[1:0]};   //E000
+			5'b11100:{ramw,mirror}<={prg_din[7],prg_din[1:0]};   //E000
 			//5'b11101:irqlatch<=nesprgdin;      //E008/10
 			//5'b11110:{irqM,irqA}<={nesprgdin[2],nesprgdin[0]}; //F000
 		endcase

--- a/mappers/misc.sv
+++ b/mappers/misc.sv
@@ -1,5 +1,5 @@
 // These are misc small one-off mappers. Some may end up being merged with Generic mappers.
-
+// altera message_off 10027
 // #15 -  100-in-1 Contra Function 16
 module Mapper15(
 	input        clk,         // System clock

--- a/ppu.sv
+++ b/ppu.sv
@@ -29,6 +29,9 @@ reg [14:0] loopy_t;
 reg [2:0] loopy_x;
 // Latch
 reg ppu_address_latch;
+reg [7:0] din_shift[2];
+reg [1:0] write_shift;
+reg [1:0] latch_shift;
 
 initial begin
 	ppu_incr = 0;
@@ -85,13 +88,6 @@ always @(posedge clk) if (ce) begin
 		end
 		ppu_address_latch <= !ppu_address_latch;
 	end else if (write && ain == 6) begin
-		if (!ppu_address_latch) begin
-			loopy_t[13:8] <= din[5:0];
-			loopy_t[14] <= 0;
-		end else begin
-			loopy_t[7:0] <= din;
-			loopy_v <= {loopy_t[14:8], din};
-		end
 		ppu_address_latch <= !ppu_address_latch;
 	end else if (read && ain == 2) begin
 		ppu_address_latch <= 0; //Reset PPU address latch
@@ -118,6 +114,21 @@ always @(posedge clk) if (ce) begin
 					loopy_v[9:5] <= loopy_v[9:5] + 1'd1;
 				end
 			end
+		end
+	end
+
+	// Writes to vram address appear to be delayed by 2 cycles
+	latch_shift <= {latch_shift[0], ppu_address_latch};
+	write_shift <= {write_shift[0], (write && ain == 6)};
+	din_shift <= '{din, din_shift[0]};
+
+	if (write_shift[1]) begin
+		if (!latch_shift[1]) begin
+			loopy_t[13:8] <= din_shift[1][5:0];
+			loopy_t[14] <= 0;
+		end else begin
+			loopy_t[7:0] <= din_shift[1];
+			loopy_v <= {loopy_t[14:8], din_shift[1]};
 		end
 	end
 end
@@ -154,6 +165,7 @@ wire [8:0] vblank_start_sl;
 wire [8:0] vblank_end_sl;
 wire [8:0] last_sl;
 wire skip_en;
+reg [3:0] rendering_sr;
 
 always_comb begin
 	case (sys_type)
@@ -183,7 +195,7 @@ assign at_last_cycle_group = (cycle[8:3] == 42);
 // In Visual 2C02, the counter starts at zero and flips at scanline 256.
 assign short_frame = end_of_line & skip_pixel;
 
-wire skip_pixel = is_pre_render && ~even_frame_toggle && is_rendering && skip_en;
+wire skip_pixel = is_pre_render && ~even_frame_toggle && rendering_sr[3] && skip_en;
 assign end_of_line = at_last_cycle_group && (cycle[3:0] == (skip_pixel ? 3 : 4));
 
 // Confimed with Visual 2C02
@@ -198,13 +210,14 @@ wire new_is_in_vblank = entering_vblank ? 1'b1 : exiting_vblank ? 1'b0 : is_in_v
 
 // Set if the current line is line 0..239
 always @(posedge clk) if (reset) begin
-	cycle <= 0;
+	cycle <= 338;
 	is_in_vblank <= 0;
 end else if (ce) begin
+	// On a real AV famicom, the NMI even_odd_timing test fails with 09, this SR is to make that happen
+	rendering_sr <= {rendering_sr[2:0], is_rendering};
 	cycle <= end_of_line ? 9'd0 : cycle + 9'd1;
 	is_in_vblank <= new_is_in_vblank;
 end
-
 
 always @(posedge clk) if (reset) begin
 	scanline <= 0;
@@ -393,7 +406,8 @@ reg [1:0] eval_counter;
 reg old_rendering;
 reg [8:0] last_y, last_tile, last_attr;
 
-// This should happen on the third cycle of rendering
+reg overflow;
+
 if (cycle == 340 && ce) begin
 	sprite0 <= sprite0_curr;
 	sprite0_curr <= 0;
@@ -412,7 +426,7 @@ if (reset) begin
 	sprite0 <= 0;
 	sprite0_curr <= 0;
 	feed_cnt <= 0;
-	spr_overflow <= 0;
+	overflow <= 0;
 	eval_counter <= 0;
 	ex_ovr <= 0;
 	oam_state <= STATE_IDLE;
@@ -505,7 +519,7 @@ end else if (ce) begin
 						if (~|eval_counter) begin // m is 0
 							if (scanline[7:0] >= oam_data && scanline[7:0] < oam_data + (obj_size ? 16 : 8)) begin
 								if (~oam_temp_wren)
-									spr_overflow <= 1;
+									overflow <= 1;
 								if (~|oam_addr[7:2])
 									sprite0_curr <= 1'b1;
 								eval_counter <= eval_counter + 2'd1;
@@ -593,8 +607,13 @@ end else if (ce) begin
 	if (oam_state == STATE_FETCH && rendering)
 		oam_addr <= 0;
 
-	if (is_vbe && cycle == 340)
+	// XXX: This delay is nessisary probably because the OAM handling is a cycle early
+	spr_overflow <= overflow;
+
+	if (is_vbe && cycle == 340) begin
+		overflow <= 0;
 		spr_overflow <= 0;
+	end
 
 	// Writes to OAMDATA during rendering (on the pre-render line and the visible lines 0-239,
 	// provided either sprite or background rendering is enabled) do not modify values in OAM,
@@ -717,8 +736,7 @@ wire flip_x = attr[6];
 wire flip_y = attr[7];
 wire dummy_sprite = attr[4];
 
-// XXX: Disabled for discovering mapper problems
-assign use_ex = /*~dummy_sprite &&*/ ~cycle[2] && ~masked_sprites;
+assign use_ex = ~dummy_sprite && ~cycle[2] && ~masked_sprites;
 
 // Flip incoming vram data based on flipx. Zero out the sprite if it's invalid. The bits are already flipped once.
 wire [7:0] vram_f =
@@ -852,7 +870,7 @@ module PaletteRam
 );
 
 reg [5:0] palette [32] = '{
-	6'h09, 6'h01, 6'h00, 6'h01,
+	6'h00, 6'h01, 6'h00, 6'h01,
 	6'h00, 6'h02, 6'h02, 6'h0D,
 	6'h08, 6'h10, 6'h08, 6'h24,
 	6'h00, 6'h00, 6'h04, 6'h2C,
@@ -871,7 +889,7 @@ assign dout = palette[addr2];
 
 always @(posedge clk) if (reset)
 	palette <= '{
-		6'h09, 6'h01, 6'h00, 6'h01,
+		6'h00, 6'h01, 6'h00, 6'h01,
 		6'h00, 6'h02, 6'h02, 6'h0D,
 		6'h08, 6'h10, 6'h08, 6'h24,
 		6'h00, 6'h00, 6'h04, 6'h2C,
@@ -898,8 +916,6 @@ module PPU(
 	input         read,             // read
 	input         write,            // write
 	output reg    nmi,              // one while inside vblank
-	input         pre_read,
-	input         pre_write,
 	output        vram_r,           // read from vram active
 	output        vram_r_ex,        // use extra sprite address
 	output        vram_w,           // write to vram active
@@ -951,9 +967,9 @@ wire exiting_vblank;      // At the very last cycle of the vblank
 wire entering_vblank;     //
 wire is_pre_render_line;  // True while we're on the pre render scanline
 
-// Confirmed in Visual 2C02, rendering enabled is latched from bck_enable and spr_enable,
-// which are themselves registers. Therefor, there is one extra cycle of delay.
-reg rendering_enabled;
+reg enable_playfield, enable_objects;
+
+wire rendering_enabled = enable_objects | enable_playfield;
 
 // 2C02 has an "is_vblank" flag that is true from pixel 0 of line 241 to pixel 0 of line 0;
 wire is_rendering = rendering_enabled && (scanline < 240 || is_pre_render_line);
@@ -1025,7 +1041,7 @@ OAMEval spriteeval (
 	.clk               (clk),
 	.ce                (ce),
 	.reset             (reset),
-	.rendering_enabled (enable_objects | enable_playfield),
+	.rendering_enabled (rendering_enabled),
 	.obj_size          (obj_size),
 	.scanline          (scanline),
 	.cycle             (cycle),
@@ -1112,10 +1128,9 @@ wire [4:0] obj_pixel = {obj_pixel_noblank[4:2], show_obj_on_pixel ? obj_pixel_no
 
 reg sprite0_hit_bg;            // True if sprite#0 has collided with the BG in the last frame.
 always @(posedge clk) if (ce) begin
-	rendering_enabled <= (enable_objects | enable_playfield);
-	if (cycle == 340 && is_vbe_sl) // confirmed with visual 2C02 (261, 1);
+	if (cycle == 340 && is_vbe_sl) begin
 		sprite0_hit_bg <= 0;
-	else if (
+	end else if (
 		is_rendering        &&    // Object rendering is enabled
 		!cycle[8]           &&    // X Pixel 0..255
 		cycle[7:0] != 255   &&    // X pixel != 255
@@ -1155,8 +1170,6 @@ always_comb begin
 		else
 			vram_r_ex = 0;
 
-		//if (cycle > 336)                                                   // Dummy nametable?
-		//		vram_a = {2'b10, loopy[11:0]};
 		if (cycle[2:1] == 0)
 			vram_a = {2'b10, loopy[11:0]};                                   // Name Table
 		else if (cycle[2:1] == 1)
@@ -1169,12 +1182,12 @@ always_comb begin
 end
 
 // Read from VRAM, either when user requested a manual read, or when we're generating pixels.
-wire vram_r_ppudata = pre_read && (ain == 7);
+wire vram_r_ppudata = read && (ain == 7);
 
 assign vram_r = vram_r_ppudata || is_rendering && cycle[0] == 0 && !end_of_line;
 
 // Write to VRAM?
-assign vram_w = pre_write && (ain == 7) && !is_pal_address && !is_rendering;
+assign vram_w = write && (ain == 7) && !is_pal_address && !is_rendering;
 
 wire [5:0] color2;
 wire [4:0] pram_addr = is_rendering ?
@@ -1197,9 +1210,11 @@ wire mask_left = (cycle < 8) && ((|mask && ~&mask) || auto_mask);
 wire mask_right = cycle > 247 && mask == 2'b10;
 // PAL/Dendy masks scanline 0 and 2 pixels on each side with black.
 wire mask_pal = (|sys_type && pal_mask);
-assign color = (mask_right | mask_left | mask_pal) ? 6'h0E : (grayscale ? {color2[5:4], 4'b0} : color2);
+wire [5:0] color1 = (grayscale ? {color2[5:4], 4'b0} : color2);
+assign color = (mask_right | mask_left | mask_pal) ? 6'h0E : color1;
 
-reg enable_playfield, enable_objects;
+wire clear_nmi = (exiting_vblank | (read && ain == 2));
+wire set_nmi = entering_vblank & ~clear_nmi;
 
 always @(posedge clk)
 if (ce) begin
@@ -1228,14 +1243,9 @@ if (ce) begin
 		endcase
 	end
 	// https://wiki.nesdev.com/w/index.php/NMI
-	// Reset frame specific counters upon exiting vblank
-	if (exiting_vblank)
-		nmi_occured <= 0;
-	// Set the
-	if (entering_vblank)
+	if (set_nmi)
 		nmi_occured <= 1;
-	// Reset NMI register when reading from Status
-	if (read && ain == 2)
+	if (clear_nmi)
 		nmi_occured <= 0;
 end
 
@@ -1284,42 +1294,42 @@ always @(posedge clk) begin
 			decay_low <= decay_low - 1'b1;
 		else
 			latched_dout[4:0] <= 5'b00000;
+	end
 
-		if (read) begin
-			case (ain)
-				2: begin
-					latched_dout <= {nmi_occured,
-									sprite0_hit_bg,
-									sprite_overflow,
-									latched_dout[4:0]};
-					refresh_high <= 1'b1;
-				end
+	if (read) begin
+		case (ain)
+			2: begin
+				latched_dout <= {nmi_occured,
+								sprite0_hit_bg,
+								sprite_overflow,
+								latched_dout[4:0]};
+				refresh_high <= 1'b1;
+			end
 
-				4: begin
-					latched_dout <= oam_bus;
+			4: begin
+				latched_dout <= oam_bus;
+				refresh_high <= 1'b1;
+				refresh_low <= 1'b1;
+			end
+
+			7: if (is_pal_address) begin
+					latched_dout <= {latched_dout[7:6], color1};
+					refresh_low <= 1'b1;
+				end else begin
+					latched_dout <= vram_latch;
 					refresh_high <= 1'b1;
 					refresh_low <= 1'b1;
 				end
+			default: latched_dout <= latched_dout;
+		endcase
 
-				7: if (is_pal_address) begin
-						latched_dout <= {latched_dout[7:6], color};
-						refresh_low <= 1'b1;
-					end else begin
-						latched_dout <= vram_latch;
-						refresh_high <= 1'b1;
-						refresh_low <= 1'b1;
-					end
-				default: latched_dout <= latched_dout;
-			endcase
+		if (reset)
+			latched_dout <= 8'd0;
 
-			if (reset)
-				latched_dout <= 8'd0;
-
-		end else if (write) begin
-			refresh_high <= 1'b1;
-			refresh_low <= 1'b1;
-			latched_dout <= din;
-		end
+	end else if (write) begin
+		refresh_high <= 1'b1;
+		refresh_low <= 1'b1;
+		latched_dout <= din;
 	end
 end
 


### PR DESCRIPTION
Several timing related fixes. Passes 3 more tests.
Resolves #129 (Indiana Jones)
Resolves flickering line on Zelda 2 title screen
Resolves colored line on Micro Machines title screen

Also preliminary support for Mapper 4, submapper 3 (Acclaim's MMC3) based on Krikzz's new findings.
This is used in Mickey's Safari in Letterland and Incredible Crash Dummies 