### PR TITLE
Fixes for mapper 32, 88, 97

### DIFF
--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -126,12 +126,12 @@ MMC1 mmc1(
 
 //*****************************************************************************//
 // Name   : Tepples                                                            //
-// Mappers: 0, 2, 3, 7, 28, 94, 180                                            //
+// Mappers: 0, 2, 3, 7, 28, 94, 97, 180, 185                                   //
 // Status : Working                                                            //
 // Notes  : This mapper relies on open bus and bus conflict behavior.          //
 // Games  : Donkey Kong                                                        //
 //*****************************************************************************//
-wire mapper28_en = me[0] | me[2] | me[3] | me[7] | me[94] | me[180] | me[185] | me[28];
+wire mapper28_en = me[0] | me[2] | me[3] | me[7] | me[94] | me[97] | me[180] | me[185] | me[28];
 Mapper28 map28(
 	.clk        (clk),
 	.ce         (ce),

--- a/rtl/mappers/MMC3.sv
+++ b/rtl/mappers/MMC3.sv
@@ -377,7 +377,7 @@ end else if (ce) begin
 
 		if (mapper154)
 			mirroring <= !prg_din[6];
-		if (DxROM || mapper76)
+		if (DxROM || mapper76 || mapper88)
 			mirroring <= flags[14]; // Hard-wired mirroring
 	end
 	else if (regs_7e && prg_write && prg_ain[15:4]==12'h7EF) begin

--- a/rtl/mappers/misc.sv
+++ b/rtl/mappers/misc.sv
@@ -555,6 +555,7 @@ reg [7:0] chrreg7;
 reg prgmode;
 reg mirror;
 wire submapper1 = (flags[21] == 1); // default (0) default submapper; (1) Major League
+wire ram_support = (flags[29:26] == 4'd7); // Image Fight (Japan)
 reg [4:0] prgsel;
 reg [7:0] chrsel;
 
@@ -610,9 +611,12 @@ always begin
 	endcase
 end
 
+wire [21:0] prg_ram = {9'b11_1100_000, prg_ain[12:0]};
+wire prg_is_ram = (prg_ain[15:13] == 3'b011) && ram_support; // $6000-$7FFF
+
 assign vram_ce = chr_ain[13];
-assign prg_aout = {4'b00_00, prgsel, prg_ain[12:0]};
-assign prg_allow = prg_ain[15] && !prg_write;
+assign prg_aout = prg_is_ram ? prg_ram : {4'b00_00, prgsel, prg_ain[12:0]};
+assign prg_allow = prg_ain[15] && !prg_write || prg_is_ram;
 assign chr_allow = flags[15];
 assign chr_aout = {4'b10_00, chrsel, chr_ain[9:0]};
 


### PR DESCRIPTION
mapper 32: add WRAM support for Image fight (Japan)
mapper 88: needs hard-wired mirroring (Kitrinx)
mapper 97: missing mapper enable