### PR TITLE
Reenable Miracle Piano

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -206,7 +206,7 @@ video_freak video_freak
 
 `include "build_id.v"
 parameter CONF_STR = {
-	"NES;SS3E000000:200000;",
+	"NES;SS3E000000:200000,UART31250,MIDI;",
 	"FS,NESFDSNSF;",
 	"H1F2,BIN,Load FDS BIOS;",
 	"-;",


### PR DESCRIPTION
Add Midi option back to config string to allow use of Miracle Piano through MidiLink.
- UART31250 isn't strictly needed, just MIDI; but setting up MIDI in the menu currently requires at least one UART speed setting.