### PR TITLE
Add header license info for UART code from Minimig

### DIFF
--- a/rtl/miracle.sv
+++ b/rtl/miracle.sv
@@ -1,4 +1,25 @@
-/* Miracle Piano for MiSTER NES by GreyRogue. UART Code copied from paula_uart from Minimg */
+/* Miracle Piano for MiSTER NES by GreyRogue. UART Code copied from paula_uart.v from Minimg */
+/* The following header is copied from paula.v */
+//
+// Copyright 2006, 2007 Dennis van Weeren
+//
+// This file is part of Minimig
+//
+// Minimig is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or
+// (at your option) any later version.
+//
+// Minimig is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//
+/* */
 
 // Uses 512 byte ring buffers for receive and transmit
 // Doesn't handle CTS/DTS, etc.


### PR DESCRIPTION
Adding license info for the UART code copied from the Minimig project in MiSTer.
At the time of adding this code, I didn't do a thorough enough search to find this header (as it wasn't in the original [paula_uart.v]).
Having been pointed to a different file (paula.v) for the header, this is now being updated to match.