### PR TITLE
Apply emphasis bits according to cycles

### DIFF
--- a/rtl/video.sv
+++ b/rtl/video.sv
@@ -321,6 +321,7 @@ localparam VBL_END   = 511;
 wire is_padding = (hc > 255);
 
 reg dark_r, dark_g, dark_b;
+reg dark_r2, dark_g2, dark_b2;
 // bits are in order {B, G, R} for NTSC color emphasis
 // Only effects range $00-$0D, $10-$1D, $20-$2D, and $30-$3D
 always @(posedge clk) if (pix_ce_n) begin
@@ -328,13 +329,16 @@ always @(posedge clk) if (pix_ce_n) begin
 
 	if (~&color_ef[3:1]) begin // Only applies in draw range
 		dark_r <= emphasis[1] | emphasis[2];
+		dark_r2 <= emphasis[1] & emphasis[2];
 		dark_g <= emphasis[0] | emphasis[2];
+		dark_g2 <= emphasis[0] & emphasis[2];
 		dark_b <= emphasis[0] | emphasis[1];
+		dark_b2 <= emphasis[0] | emphasis[1];
 	end
 end
 
-assign R = dark_r ? pixel[23:17] + pixel[23:18] : pixel[23:16];
-assign G = dark_g ? pixel[15:9]  + pixel[15:10] : pixel[15:8];
-assign B = dark_b ? pixel[7:1]   + pixel[7:2]   : pixel[7:0];
+assign R = dark_r2 ? pixel[23:17] + pixel[23:18] : dark_r ? pixel[23:17] + pixel[23:18] + pixel[23:20] : pixel[23:16];
+assign G = dark_g2 ? pixel[15:9]  + pixel[15:10] : dark_g ? pixel[15:9]  + pixel[15:10] + pixel[15:12] : pixel[15:8];
+assign B = dark_b2 ? pixel[7:1]   + pixel[7:2]   : dark_b ? pixel[7:1]   + pixel[7:2]   + pixel[7:4]   : pixel[7:0];
 
 endmodule


### PR DESCRIPTION
Reasoning:
- There are 12 color cycles.  4 for each color.
- A completely darkened color from emphasis is 3/4 of normal.
- Full darkness occurs when all 4/4 color clocks are darkened.
- A single emphasis reduction only darkens 6/12 color clocks.  This is 3 from each of the 2 darkened colors.
- So if 4/4 darkness results in 3/4 brightness, then 3/4 should be 13/16 max brightness. (aka 1/16 brightness reduction per color cycle).