### PR TITLE
Add savestate support for various mappers

### DIFF
--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -217,7 +217,14 @@ Mapper30 map30(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[26])
 );
 
 //*****************************************************************************//
@@ -248,7 +255,14 @@ Mapper32 map32(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[28])
 );
 
 //*****************************************************************************//
@@ -565,7 +579,14 @@ Mapper18 map18(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[27])
 );
 
 //*****************************************************************************//
@@ -596,7 +617,14 @@ Mapper34 map34(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[31])
 );
 
 //*****************************************************************************//
@@ -689,7 +717,14 @@ Mapper65 map65(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[29])
 );
 
 //*****************************************************************************//
@@ -759,7 +794,14 @@ Mapper67 map67(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[20])
 );
 
 //*****************************************************************************//
@@ -790,7 +832,14 @@ Mapper68 map68(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[21])
 );
 
 //*****************************************************************************//
@@ -897,7 +946,14 @@ Mapper72 map72(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[30])
 );
 
 //*****************************************************************************//
@@ -928,7 +984,14 @@ Mapper77 map77(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[32])
 );
 
 //*****************************************************************************//
@@ -959,7 +1022,14 @@ Mapper78 map78(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[33])
 );
 
 //*****************************************************************************//
@@ -1060,7 +1130,14 @@ Mapper89 map89(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[34])
 );
 
 //*****************************************************************************//
@@ -1122,7 +1199,14 @@ Mapper111 map111(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[25])
 );
 
 //*****************************************************************************//
@@ -1345,7 +1429,14 @@ Rambo1 rambo1(
 	.audio_in   (audio_in),
 	.audio_b    (audio_out_b),
 	// Special ports
-	.chr_ain_o  (chr_ain_orig)
+	.chr_ain_o  (chr_ain_orig),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[24])
 );
 
 //*****************************************************************************//
@@ -1408,7 +1499,14 @@ VRC1 vrc1(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[18])
 );
 
 //*****************************************************************************//
@@ -1439,7 +1537,14 @@ VRC3 vrc3(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[19])
 );
 
 //*****************************************************************************//
@@ -1715,7 +1820,14 @@ Sachen8259 sachen(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[22])
 );
 
 //*****************************************************************************//
@@ -1747,7 +1859,14 @@ SachenJV001 sachenj(
 	.irq_b      (irq_b),
 	.flags_out_b(flags_out_b),
 	.audio_in   (audio_in),
-	.audio_b    (audio_out_b)
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[23])
 );
 
 //*****************************************************************************//
@@ -2149,13 +2268,16 @@ always @* begin
 end
 
 // savestates
-localparam SAVESTATE_MODULES    = 18;
+localparam SAVESTATE_MODULES    = 35;
 wire [63:0] SaveStateBus_wired_or[0:SAVESTATE_MODULES-1];
 
 assign SaveStateBus_Dout  = SaveStateBus_wired_or[ 0] | SaveStateBus_wired_or[ 1] | SaveStateBus_wired_or[ 2] | SaveStateBus_wired_or[ 3] | SaveStateBus_wired_or[ 4] | 
 									 SaveStateBus_wired_or[ 5] | SaveStateBus_wired_or[ 6] | SaveStateBus_wired_or[ 7] | SaveStateBus_wired_or[ 8] | SaveStateBus_wired_or[ 9] |
 									 SaveStateBus_wired_or[10] | SaveStateBus_wired_or[11] | SaveStateBus_wired_or[12] | SaveStateBus_wired_or[13] | SaveStateBus_wired_or[14] |
-									 SaveStateBus_wired_or[15] | SaveStateBus_wired_or[16] | SaveStateBus_wired_or[17];
+									 SaveStateBus_wired_or[15] | SaveStateBus_wired_or[16] | SaveStateBus_wired_or[17] | SaveStateBus_wired_or[18] | SaveStateBus_wired_or[19] |
+									 SaveStateBus_wired_or[20] | SaveStateBus_wired_or[21] | SaveStateBus_wired_or[22] | SaveStateBus_wired_or[23] | SaveStateBus_wired_or[24] |
+									 SaveStateBus_wired_or[25] | SaveStateBus_wired_or[26] | SaveStateBus_wired_or[27] | SaveStateBus_wired_or[28] | SaveStateBus_wired_or[29] |
+									 SaveStateBus_wired_or[30] | SaveStateBus_wired_or[31] | SaveStateBus_wired_or[32] | SaveStateBus_wired_or[33] | SaveStateBus_wired_or[34];
 
 localparam SAVESTATERAM_MODULES    = 2;
 wire [7:0] SaveStateRAM_wired_or[0:SAVESTATE_MODULES-1];

--- a/rtl/mappers/Sachen.sv
+++ b/rtl/mappers/Sachen.sv
@@ -23,7 +23,14 @@ module Sachen8259(
 	inout        irq_b,       // IRQ
 	input [15:0] audio_in,    // Inverted audio from APU
 	inout [15:0] audio_b,     // Mixed audio output
-	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout}
+	inout [15:0] flags_out_b, // flags {0, 0, 0, 0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout}
+	// savestates              
+	input       [63:0]  SaveStateBus_Din,
+	input       [ 9:0]  SaveStateBus_Adr,
+	input               SaveStateBus_wren,
+	input               SaveStateBus_rst,
+	input               SaveStateBus_load,
+	output      [63:0]  SaveStateBus_Dout
 );
 
 assign prg_aout_b   = enable ? prg_aout : 22'hZ;
@@ -42,7 +49,7 @@ wire prg_allow;
 wire chr_allow;
 wire vram_a10;
 wire vram_ce;
-wire [15:0] flags_out = {14'd0, prg_bus_write, 1'b0};
+wire [15:0] flags_out = {12'd0, 1'b1, 1'b0, prg_bus_write, 1'b0};
 
 // 0x4100
 wire [7:0] prg_dout = {5'b00111, (~register)}; // ^ (counter & 0x1)
@@ -63,6 +70,16 @@ reg [2:0] mirroring;
 always @(posedge clk)
 if (~enable) begin
 	//any resets?
+end else if (SaveStateBus_load) begin
+	register   <= SS_MAP1[ 2: 0];
+	prg_bank   <= SS_MAP1[ 5: 3];
+	chr_bank_0 <= SS_MAP1[ 8: 6];
+	chr_bank_1 <= SS_MAP1[11: 9];
+	chr_bank_2 <= SS_MAP1[14:12];
+	chr_bank_3 <= SS_MAP1[17:15];
+	chr_bank_o <= SS_MAP1[20:18];
+	chr_bank_p <= SS_MAP1[23:21];
+	mirroring  <= SS_MAP1[26:24];
 end else if (ce && prg_write) begin
 	if ({prg_ain[15:14], prg_ain[8], prg_ain[0]} == 4'b0110) begin
 		register <= prg_din[2:0];
@@ -85,6 +102,17 @@ end else if (ce && prg_write) begin
 		endcase
 	end
 end
+
+assign SS_MAP1_BACK[ 2: 0] = register;
+assign SS_MAP1_BACK[ 5: 3] = prg_bank;
+assign SS_MAP1_BACK[ 8: 6] = chr_bank_0;
+assign SS_MAP1_BACK[11: 9] = chr_bank_1;
+assign SS_MAP1_BACK[14:12] = chr_bank_2;
+assign SS_MAP1_BACK[17:15] = chr_bank_3;
+assign SS_MAP1_BACK[20:18] = chr_bank_o;
+assign SS_MAP1_BACK[23:21] = chr_bank_p;
+assign SS_MAP1_BACK[26:24] = mirroring;
+assign SS_MAP1_BACK[63:27] = 37'b0; // free to be used
 
 // The CHR bank to load. Each increment here is 1kb. So valid values are 0..255.
 wire [2:0] chr_bank;
@@ -138,6 +166,14 @@ assign vram_ce = chr_ain[13];
 //assign vram_a10 = ; //done above
 assign prg_allow = prg_ain[15] && !prg_write;
 
+// savestate
+wire [63:0] SS_MAP1;
+wire [63:0] SS_MAP1_BACK;	
+wire [63:0] SaveStateBus_Dout_active;	
+eReg_SavestateV #(SSREG_INDEX_MAP1, 64'h0000000000000000) iREG_SAVESTATE_MAP1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_Dout_active, SS_MAP1_BACK, SS_MAP1);  
+
+assign SaveStateBus_Dout = enable ? SaveStateBus_Dout_active : 64'h0000000000000000;
+
 endmodule
 
 // #136,#147 - Sachen JV001
@@ -165,7 +201,14 @@ module SachenJV001(
 	inout        irq_b,       // IRQ
 	input [15:0] audio_in,    // Inverted audio from APU
 	inout [15:0] audio_b,     // Mixed audio output
-	inout [15:0] flags_out_b  // flags {0, 0, 0, 0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout}
+	inout [15:0] flags_out_b, // flags {0, 0, 0, 0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout}
+	// savestates              
+	input       [63:0]  SaveStateBus_Din,
+	input       [ 9:0]  SaveStateBus_Adr,
+	input               SaveStateBus_wren,
+	input               SaveStateBus_rst,
+	input               SaveStateBus_load,
+	output      [63:0]  SaveStateBus_Dout
 );
 
 assign prg_aout_b   = enable ? prg_aout : 22'hZ;
@@ -184,7 +227,7 @@ wire prg_allow;
 wire chr_allow;
 wire vram_a10;
 wire vram_ce;
-wire [15:0] flags_out = {14'd0, prg_bus_write, 1'b0};
+wire [15:0] flags_out = {12'd0, 1'b1, 1'b0, prg_bus_write, 1'b0};
 
 reg [5:0] input_reg; //s_reg = input_reg[3]
 reg [5:0] output_reg;
@@ -211,6 +254,14 @@ wire prg_bus_write = (prg_ain[15:13] == 3'b010 && prg_ain[8]); //0x4100-3
 always @(posedge clk)
 if (~enable) begin
 	//
+end else if (SaveStateBus_load) begin
+	input_reg   <= SS_MAP1[ 5: 0];
+	output_reg  <= SS_MAP1[11: 6];
+	register_reg<= SS_MAP1[17:12];
+	inc_reg     <= SS_MAP1[   18];
+	invert_reg  <= SS_MAP1[   19];
+	alt_chr     <= SS_MAP1[23:20];
+	mirroring   <= SS_MAP1[   24];
 end else if (ce) begin
 	if (prg_ain[15:13] == 3'b010 && prg_ain[8] && prg_write) //0x4100-3
 		case (prg_ain[1:0])
@@ -231,6 +282,15 @@ end else if (ce) begin
 		mirroring <= invert_reg;
 	end
 end
+
+assign SS_MAP1_BACK[ 5: 0] = input_reg;
+assign SS_MAP1_BACK[11: 6] = output_reg;
+assign SS_MAP1_BACK[17:12] = register_reg;
+assign SS_MAP1_BACK[   18] = inc_reg;
+assign SS_MAP1_BACK[   19] = invert_reg;
+assign SS_MAP1_BACK[23:20] = alt_chr;
+assign SS_MAP1_BACK[   24] = mirroring;
+assign SS_MAP1_BACK[63:25] = 39'b0; // free to be used
 
 // 0x4100-3
 wire use_s = mapper132 | mapper173;
@@ -257,6 +317,14 @@ assign chr_allow = flags[15];
 assign chr_aout = {5'b10_000, chr_sel, chr_ain[12:0]};
 assign vram_ce = chr_ain[13];
 assign vram_a10 = (mapper172 ? mirroring : flags[14]) ? chr_ain[10] : chr_ain[11]; // 0: horiz, 1: vert
+
+// savestate
+wire [63:0] SS_MAP1;
+wire [63:0] SS_MAP1_BACK;	
+wire [63:0] SaveStateBus_Dout_active;	
+eReg_SavestateV #(SSREG_INDEX_MAP1, 64'h0000000000000000) iREG_SAVESTATE_MAP1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_Dout_active, SS_MAP1_BACK, SS_MAP1);  
+
+assign SaveStateBus_Dout = enable ? SaveStateBus_Dout_active : 64'h0000000000000000;
 
 endmodule
 
@@ -302,7 +370,7 @@ wire chr_allow;
 wire vram_a10;
 wire vram_ce;
 wire prg_bus_write;
-wire [15:0] flags_out = {14'h0, prg_bus_write, 1'b0};
+wire [15:0] flags_out = {12'h0, 1'b1, 1'b0, prg_bus_write, 1'b0};
 
 // 0x4100
 wire [7:0] prg_dout = {2'b01, ~prg_ain[5:0]}; // top 2 bits are actually open bus


### PR DESCRIPTION
The following mappers now support save states:
- 30, 32, 18, 34, 65, 67, 190, 68, 72, 92, 77, 78, 70, 152, 89, 93, 184, 111, 64, 158,  75, 73, 137, 138, 139, 141, 150, 243, 136, 147, 132, 173, 172, 36, 143, 218
,