### PR TITLE
Cleanup menu and palettes

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -164,7 +164,7 @@ assign AUDIO_L   = sample[15:0];
 assign AUDIO_R   = AUDIO_L;
 assign AUDIO_MIX = 0;
 
-assign LED_USER  = downloading | (loader_fail & led_blink) | (bk_state != S_IDLE) | (bk_pending & status[17]);
+assign LED_USER  = downloading | (loader_fail & led_blink) | (bk_state != S_IDLE) | (bk_pending & status[50]);
 assign LED_DISK  = 0;
 assign LED_POWER = 0;
 assign BUTTONS [1] = 0;
@@ -200,7 +200,7 @@ video_freak video_freak
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXX XX XXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXX
+// XXXXXXXX XX     X XXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXX
 
 `include "build_id.v"
 parameter CONF_STR = {
@@ -210,13 +210,13 @@ parameter CONF_STR = {
 	"-;",
 	"ONO,System Type,NTSC,PAL,Dendy;",
 	"OG,Disk Swap,Auto,FDS button;",
-	"OCF,Palette,Smooth,Unsat.,FCEUX,NES Classic,Composite,PC-10,PVM,Wavebeam,Real,Sony CXA,YUV,Greyscale,Rockman9,Ninten.,Custom;",
+	"oFH,Palette,Kitrinx,Smooth,Wavebeam,Sony CXA,PC-10 Better,Custom;",
 	"H3FC3,PAL,Custom Palette;",
 	"-;",
 	"C,Cheats;",
 	"H2OK,Cheats Enabled,On,Off;",
 	"-;",
-	"OH,Autosave,Off,On;",
+	"oI,Autosave,On,Off;",
 	"H5D0R6,Load Backup RAM;",
 	"H5D0R7,Save Backup RAM;",
 	"-;",
@@ -287,7 +287,7 @@ wire [63:0] status;
 wire arm_reset = status[0];
 wire pal_video = |status[24:23];
 wire hide_overscan = status[4] && ~pal_video;
-wire [3:0] palette2_osd = status[15:12];
+wire [3:0] palette2_osd = status[49:47];
 wire joy_swap = status[9] ^ (raw_serial || piano); // Controller on port 2 for Miracle Piano/SNAC
 wire fds_swap_invert = status[16];
 wire ext_audio = ~status[30];
@@ -310,7 +310,7 @@ always_ff @(posedge clk) begin
 			2'b00: begin type_bios <= 1; is_bios <= 1; downloading <= ioctl_downloading; end
 			2'b01: begin type_nes <= 1; downloading <= ioctl_downloading; end
 			2'b10: begin type_fds <= 1; downloading <= ioctl_downloading; end
-			2'b11: begin type_palette <= 1; end
+			//2'b11: begin type_palette <= 1; end
 		endcase
 	else if(&filetype)
 		type_gg <= 1;
@@ -395,7 +395,7 @@ hps_io #(.CONF_STR(CONF_STR)) hps_io
 	.paddle_3(pdl[3]),
 
 	.status(status),
-	.status_menumask({(rom_loaded && mapper_has_savestate), en216p, status[17], ~raw_serial, (palette2_osd != 4'd14), ~gg_avail, bios_loaded, ~bk_ena}),
+	.status_menumask({(rom_loaded && mapper_has_savestate), en216p, status[50], ~raw_serial, (palette2_osd != 3'd5), ~gg_avail, bios_loaded, ~bk_ena}),
 	.status_in({status[63:47],ss_slot,status[44:0]}),
 	.status_set(statusUpdate),
 	.info_req(info_req),
@@ -1184,7 +1184,7 @@ always @(posedge clk) begin
 end
 
 wire bk_load    = status[6];
-wire bk_save    = status[7] | (bk_pending & OSD_STATUS && status[17]);
+wire bk_save    = status[7] | (bk_pending & OSD_STATUS && status[50]);
 reg  bk_loading = 0;
 reg  bk_loading_req = 0;
 reg  bk_request = 0;

--- a/rtl/video.sv
+++ b/rtl/video.sv
@@ -40,6 +40,17 @@ always @(negedge clk) begin
 end
 
 assign ce_pix = pix_ce;
+// Kitrinx 34 palette by Kitrinx
+wire [23:0] pal_kitrinx_lut[64] = '{
+	'h666666, 'h01247B, 'h1B1489, 'h39087C, 'h520257, 'h5C0725, 'h571300, 'h472300,
+	'h2D3300, 'h0E4000, 'h004500, 'h004124, 'h003456, 'h000000, 'h000000, 'h000000,
+	'hADADAD, 'h2759C9, 'h4845DB, 'h6F34CA, 'h922B9B, 'hA1305A, 'h9B4018, 'h885400,
+	'h686700, 'h3E7A00, 'h1B8213, 'h0D7C57, 'h136C99, 'h000000, 'h000000, 'h000000,
+	'hFFFFFF, 'h78ABFF, 'h9897FF, 'hC086FF, 'hE27DEF, 'hF281AF, 'hED916D, 'hDBA43B,
+	'hBDB825, 'h92CB33, 'h6DD463, 'h5ECEA8, 'h65BEEA, 'h525252, 'h000000, 'h000000,
+	'hFFFFFF, 'hCADBFF, 'hD8D2FF, 'hE7CCFF, 'hF4C9F9, 'hFACBDF, 'hF7D2C4, 'hEEDAAF,
+	'hE1E3A5, 'hD0EBAB, 'hC2EEBF, 'hBDEBDB, 'hC0E4F7, 'hB8B8B8, 'h000000, 'h000000
+};
 
 // Smooth palette from FirebrandX
 wire [23:0] pal_smooth_lut[64] = '{
@@ -53,77 +64,16 @@ wire [23:0] pal_smooth_lut[64] = '{
 	'hF1F0AA, 'hDAFAA9, 'hC9FFBC, 'hC3FBD7, 'hC4F6F6, 'hBEC1BE, 'h000000, 'h000000
 };
 
-// NTSC UnsaturatedV6 palette
-//see: http://www.firebrandx.com/nespalette.html
-wire [23:0] pal_unsat_lut[64] = '{
-	'h6B6B6B, 'h001E87, 'h1F0B96, 'h3B0C87, 'h590D61, 'h5E0528, 'h551100, 'h461B00,
-	'h303200, 'h0A4800, 'h004E00, 'h004619, 'h003A58, 'h000000, 'h000000, 'h000000,
-	'hB2B2B2, 'h1A53D1, 'h4835EE, 'h7123EC, 'h9A1EB7, 'hA51E62, 'hA52D19, 'h874B00,
-	'h676900, 'h298400, 'h038B00, 'h008240, 'h007891, 'h000000, 'h000000, 'h000000,
-	'hFFFFFF, 'h63ADFD, 'h908AFE, 'hB977FC, 'hE771FE, 'hF76FC9, 'hF5836A, 'hDD9C29,
-	'hBDB807, 'h84D107, 'h5BDC3B, 'h48D77D, 'h48CCCE, 'h555555, 'h000000, 'h000000,
-	'hFFFFFF, 'hC4E3FE, 'hD7D5FE, 'hE6CDFE, 'hF9CAFE, 'hFEC9F0, 'hFED1C7, 'hF7DCAC,
-	'hE8E89C, 'hD1F29D, 'hBFF4B1, 'hB7F5CD, 'hB7F0EE, 'hBEBEBE, 'h000000, 'h000000
-};
-
-// FCEUX palette
-wire [23:0] pal_fcelut[64] = '{
-	'h747474, 'h24188C, 'h0000A8, 'h44009C, 'h8C0074, 'hA80010, 'hA40000, 'h7C0800,
-	'h402C00, 'h004400, 'h005000, 'h003C14, 'h183C5C, 'h000000, 'h000000, 'h000000,
-	'hBCBCBC, 'h0070EC, 'h2038EC, 'h8000F0, 'hBC00BC, 'hE40058, 'hD82800, 'hC84C0C,
-	'h887000, 'h009400, 'h00A800, 'h009038, 'h008088, 'h000000, 'h000000, 'h000000,
-	'hFCFCFC, 'h3CBCFC, 'h5C94FC, 'hCC88FC, 'hF478FC, 'hFC74B4, 'hFC7460, 'hFC9838,
-	'hF0BC3C, 'h80D010, 'h4CDC48, 'h58F898, 'h00E8D8, 'h787878, 'h000000, 'h000000,
-	'hFCFCFC, 'hA8E4FC, 'hC4D4FC, 'hD4C8FC, 'hFCC4FC, 'hFCC4D8, 'hFCBCB0, 'hFCD8A8,
-	'hFCE4A0, 'hE0FCA0, 'hA8F0BC, 'hB0FCCC, 'h9CFCF0, 'hC4C4C4, 'h000000, 'h000000
-};
-
-// NES Classic by FirebrandX
-wire [23:0] pal_nes_classic_lut[64] = '{
-	'h616161, 'h000088, 'h1F0D99, 'h371379, 'h561260, 'h5D0010, 'h520E00, 'h3A2308,
-	'h21350C, 'h0D410E, 'h174417, 'h003A1F, 'h002F57, 'h000000, 'h000000, 'h000000,
-	'hAAAAAA, 'h0D4DC4, 'h4B24DE, 'h6912CF, 'h9014AD, 'h9D1C48, 'h923404, 'h735005,
-	'h5D6913, 'h167A11, 'h138008, 'h127649, 'h1C6691, 'h000000, 'h000000, 'h000000,
-	'hFCFCFC, 'h639AFC, 'h8A7EFC, 'hB06AFC, 'hDD6DF2, 'hE771AB, 'hE38658, 'hCC9E22,
-	'hA8B100, 'h72C100, 'h5ACD4E, 'h34C28E, 'h4FBECE, 'h424242, 'h000000, 'h000000,
-	'hFCFCFC, 'hBED4FC, 'hCACAFC, 'hD9C4FC, 'hECC1FC, 'hFAC3E7, 'hF7CEC3, 'hE2CDA7,
-	'hDADB9C, 'hC8E39E, 'hBFE5B8, 'hB2EBC8, 'hB7E5EB, 'hACACAC, 'h000000, 'h000000
-};
-
-// Composite Direct by FirebrandX
-wire [23:0] pal_composite_direct_lut[64] = '{
-	'h656565, 'h00127D, 'h18008E, 'h360082, 'h56005D, 'h5A0018, 'h4F0500, 'h381900,
-	'h1D3100, 'h003D00, 'h004100, 'h003B17, 'h002E55, 'h000000, 'h000000, 'h000000,
-	'hAFAFAF, 'h194EC8, 'h472FE3, 'h6B1FD7, 'h931BAE, 'h9E1A5E, 'h993200, 'h7B4B00,
-	'h5B6700, 'h267A00, 'h008200, 'h007A3E, 'h006E8A, 'h000000, 'h000000, 'h000000,
-	'hFFFFFF, 'h64A9FF, 'h8E89FF, 'hB676FF, 'hE06FFF, 'hEF6CC4, 'hF0806A, 'hD8982C,
-	'hB9B40A, 'h83CB0C, 'h5BD63F, 'h4AD17E, 'h4DC7CB, 'h4C4C4C, 'h000000, 'h000000,
-	'hFFFFFF, 'hC7E5FF, 'hD9D9FF, 'hE9D1FF, 'hF9CEFF, 'hFFCCF1, 'hFFD4CB, 'hF8DFB1,
-	'hEDEAA4, 'hD6F4A4, 'hC5F8B8, 'hBEF6D3, 'hBFF1F1, 'hB9B9B9, 'h000000, 'h000000
-};
-
-// PC-10 by FirebrandX
+// PC-10 Better by Kitrinx
 wire [23:0] pal_pc10_lut[64] = '{
-	'h6D6D6D, 'h002492, 'h0000DB, 'h6D49DB, 'h92006D, 'hB6006D, 'hB62400, 'h924900,
-	'h6D4900, 'h244900, 'h006D24, 'h009200, 'h004949, 'h000000, 'h000000, 'h000000,
-	'hB6B6B6, 'h006DDB, 'h0049FF, 'h9200FF, 'hB600FF, 'hFF0092, 'hFF0000, 'hDB6D00,
-	'h926D00, 'h249200, 'h009200, 'h00B66D, 'h009292, 'h242424, 'h000000, 'h000000,
-	'hFFFFFF, 'h6DB6FF, 'h9292FF, 'hDB6DFF, 'hFF00FF, 'hFF6DFF, 'hFF9200, 'hFFB600,
-	'hDBDB00, 'h6DDB00, 'h00FF00, 'h49FFDB, 'h00FFFF, 'h494949, 'h000000, 'h000000,
-	'hFFFFFF, 'hB6DBFF, 'hDBB6FF, 'hFFB6FF, 'hFF92FF, 'hFFB6B6, 'hFFDB92, 'hFFFF49,
-	'hFFFF6D, 'hB6FF49, 'h92FF6D, 'h49FFDB, 'h92DBFF, 'h929292, 'h000000, 'h000000
-};
-
-// PVM by FirebrandX
-wire [23:0] pal_pvm_lut[64] = '{
-	'h696E69, 'h001774, 'h1E0087, 'h340073, 'h560057, 'h5E0013, 'h531A00, 'h3B2400,
-	'h243000, 'h063A00, 'h003F00, 'h003B1E, 'h003050, 'h000000, 'h000000, 'h000000,
-	'hB9BEB9, 'h1453B9, 'h4D2CDA, 'h671EDE, 'h98189C, 'h9D2344, 'hA03E00, 'h8D5500,
-	'h656D00, 'h2C7900, 'h008100, 'h007D42, 'h00788A, 'h000000, 'h000000, 'h000000,
-	'hFFFFFF, 'h69A8FF, 'h9691FF, 'hB28AFA, 'hEA7DFA, 'hF37BC7, 'hF18F6C, 'hE6AD27,
-	'hD7C805, 'h90DF07, 'h64E53C, 'h45E27D, 'h48D5D9, 'h4B504B, 'h000000, 'h000000,
-	'hFFFFFF, 'hD2EAFF, 'hE2E2FF, 'hE9D8FF, 'hF5D2FF, 'hF8D9EA, 'hFADEB9, 'hF9E89B,
-	'hF3F28C, 'hD3FA91, 'hB8FCA8, 'hAEFACA, 'hCAF3F3, 'hBEC3BE, 'h000000, 'h000000
+	'h6D6D6D, 'h10247C, 'h0A06B3, 'h6950C2, 'h6A0F62, 'h831264, 'h872F0F, 'h774C11,
+	'h5E490F, 'h2C430A, 'h1E612A, 'h258011, 'h164244, 'h000000, 'h000000, 'h000000,
+	'hB6B6B6, 'h2767C0, 'h1F48DA, 'h7114DA, 'h8A17DC, 'hB71987, 'hB0150F, 'hB37219,
+	'h806C15, 'h3E8313, 'h258011, 'h34A46F, 'h2C8589, 'h000000, 'h000000, 'h000000,
+	'hFFFFFF, 'h87B2ED, 'h9795EB, 'hC07BEB, 'hBD1DE1, 'hD97EED, 'hD59620, 'hDFB624,
+	'hCFD326, 'h84CA20, 'h41E11D, 'h7FEED6, 'h4EE9EF, 'h000000, 'h000000, 'h000000,
+	'hFFFFFF, 'hC3D8F6, 'hD2BBF4, 'hECBEF6, 'hE29EF2, 'hE8BCBA, 'hF0DBA0, 'hF5F969,
+	'hF7FA87, 'hC3F364, 'hACF180, 'h7FEED6, 'hAAD5F4, 'h000000, 'h000000, 'h000000
 };
 
 // Wavebeam by NakedArthur
@@ -138,18 +88,6 @@ wire [23:0] pal_wavebeam_lut[64] = '{
 	'hEBE3A0, 'hD2EDA2, 'hBCF4B4, 'hB5F1CE, 'hB6ECF1, 'hBFBFBF, 'h000000, 'h000000
 };
 
-// Reality C by Squire
-wire [23:0] pal_real_lut[64] = '{
-	'h6C6C6C, 'h00268E, 'h0000A8, 'h400094, 'h700070, 'h780040, 'h700000, 'h621600,
-	'h442400, 'h343400, 'h005000, 'h004444, 'h004060, 'h000000, 'h101010, 'h101010,
-	'hBABABA, 'h205CDC, 'h3838FF, 'h8020F0, 'hC000C0, 'hD01474, 'hD02020, 'hAC4014,
-	'h7C5400, 'h586400, 'h008800, 'h007468, 'h00749C, 'h202020, 'h101010, 'h101010,
-	'hFFFFFF, 'h4CA0FF, 'h8888FF, 'hC06CFF, 'hFF50FF, 'hFF64B8, 'hFF7878, 'hFF9638,
-	'hDBAB00, 'hA2CA20, 'h4ADC4A, 'h2CCCA4, 'h1CC2EA, 'h585858, 'h101010, 'h101010,
-	'hFFFFFF, 'hB0D4FF, 'hC4C4FF, 'hE8B8FF, 'hFFB0FF, 'hFFB8E8, 'hFFC4C4, 'hFFD4A8,
-	'hFFE890, 'hF0F4A4, 'hC0FFC0, 'hACF4F0, 'hA0E8FF, 'hC2C2C2, 'h202020, 'h101010
-};
-
 // Sony CXA by FirebrandX
 wire [23:0] pal_sonycxa_lut[64] = '{
 	'h585858, 'h00238C, 'h00139B, 'h2D0585, 'h5D0052, 'h7A0017, 'h7A0800, 'h5F1800,
@@ -162,53 +100,6 @@ wire [23:0] pal_sonycxa_lut[64] = '{
 	'hE9DE86, 'hC7E992, 'hA8EEB0, 'h95ECD9, 'h91E4FE, 'hACACAC, 'h000000, 'h000000
 };
 
-// YUV from Nestopia
-wire [23:0] pal_yuv_lut[64] = '{
-	'h666666, 'h002A88, 'h1412A7, 'h3B00A4, 'h5C007E, 'h6E0040, 'h6C0700, 'h561D00,
-	'h333500, 'h0C4800, 'h005200, 'h004F08, 'h00404D, 'h000000, 'h000000, 'h000000,
-	'hADADAD, 'h155FD9, 'h4240FF, 'h7527FE, 'hA01ACC, 'hB71E7B, 'hB53120, 'h994E00,
-	'h6B6D00, 'h388700, 'h0D9300, 'h008F32, 'h007C8D, 'h000000, 'h000000, 'h000000,
-	'hFFFFFF, 'h64B0FF, 'h9290FF, 'hC676FF, 'hF26AFF, 'hFF6ECC, 'hFF8170, 'hEA9E22,
-	'hBCBE00, 'h88D800, 'h5CE430, 'h45E082, 'h48CDDE, 'h4F4F4F, 'h000000, 'h000000,
-	'hFFFFFF, 'hC0DFFF, 'hD3D2FF, 'hE8C8FF, 'hFAC2FF, 'hFFC4EA, 'hFFCCC5, 'hF7D8A5,
-	'hE4E594, 'hCFEF96, 'hBDF4AB, 'hB3F3CC, 'hB5EBF2, 'hB8B8B8, 'h000000, 'h000000
-};
-
-// Greyscale
-wire [23:0] pal_greyscale_lut[64] = '{
-	'h747474, 'h3E3E3E, 'h343434, 'h2E2E2E, 'h393939, 'h353535, 'h303030, 'h161616,
-	'h1F1F1F, 'h3E3E3E, 'h444444, 'h3E3E3E, 'h383838, 'h000000, 'h0A0A0A, 'h0A0A0A,
-	'hB2B2B2, 'h7B7B7B, 'h696969, 'h636363, 'h707070, 'h6D6D6D, 'h6B6B6B, 'h666666,
-	'h727272, 'h7D7D7D, 'h898989, 'h838383, 'h7E7E7E, 'h353535, 'h0A0A0A, 'h0A0A0A,
-	'hF1F1F1, 'hBEBEBE, 'hA1A1A1, 'h959595, 'hA1A1A1, 'h9E9E9E, 'hA2A2A2, 'hAAAAAA,
-	'hB5B5B5, 'hBDBDBD, 'hC8C8C8, 'hC6C6C6, 'hC4C4C4, 'h606060, 'h0A0A0A, 'h0A0A0A,
-	'hF1F1F1, 'hE9E9E9, 'hD9D9D9, 'hCCCCCC, 'hCFCFCF, 'hCDCDCD, 'hCFCFCF, 'hD3D3D3,
-	'hD9D9D9, 'hDBDBDB, 'hDEDEDE, 'hDDDDDD, 'hDDDDDD, 'hBABABA, 'h0A0A0A, 'h0A0A0A
-};
-
-// Rockman9 Palette
-wire [23:0] pal_rockman9_lut[64] = '{
-	'h707070, 'h0000A8, 'h201888, 'h400098, 'h880070, 'hA80010, 'hA00000, 'h780800,
-	'h402800, 'h004000, 'h005000, 'h003810, 'h183858, 'h000000, 'h000000, 'h000000,
-	'hB8B8B8, 'h0070E8, 'h2038E8, 'h8000F0, 'hB800B8, 'hE00058, 'hD82800, 'hC84808,
-	'h887000, 'h009000, 'h00A800, 'h009038, 'h008088, 'h000000, 'h000000, 'h000000,
-	'hF8F8F8, 'h38B8F8, 'h5890F8, 'hA088F8, 'hF078F8, 'hF870B0, 'hF87060, 'hF89838,
-	'hF0B838, 'h80D010, 'h48D848, 'h58F898, 'h00E8D8, 'h505050, 'h000000, 'h000000,
-	'hF8F8F8, 'hA8E0F8, 'hC0D0F8, 'hD0C8F8, 'hF8C0F8, 'hF8C0D8, 'hF8B8B0, 'hF8D8A8,
-	'hF8E0A0, 'hE0F8A0, 'hA8F0B8, 'hB0F8C8, 'h98F8F0, 'h989898, 'h000000, 'h000000
-};
-
-// Nintendulator NTSC
-wire [23:0] pal_nintendulator_lut[64] = '{
-	'h656565, 'h002B9B, 'h110EC0, 'h3F00BC, 'h66008F, 'h7B0045, 'h790100, 'h601C00,
-	'h363800, 'h084F00, 'h005A00, 'h005702, 'h004555, 'h000000, 'h000000, 'h000000,
-	'hAEAEAE, 'h0761F5, 'h3E3BFF, 'h7C1DFF, 'hAF0EE5, 'hCB1383, 'hC82A15, 'hA74D00,
-	'h6F7200, 'h379100, 'h009F00, 'h009B2A, 'h008498, 'h000000, 'h000000, 'h000000,
-	'hFFFFFF, 'h56B1FF, 'h8E8BFF, 'hCC6CFF, 'hFF5DFF, 'hFF62D4, 'hFF7964, 'hF89D06,
-	'hC0C300, 'h81E200, 'h4DF116, 'h30EC7A, 'h34D5EA, 'h4E4E4E, 'h000000, 'h000000,
-	'hFFFFFF, 'hBADFFF, 'hD1D0FF, 'hEBC3FF, 'hFFBDFF, 'hFFBFEE, 'hFFC8C0, 'hFCD799,
-	'hEFE784, 'hCCF387, 'hB6F9A0, 'hAAF8C9, 'hACEEF7, 'hB7B7B7, 'h000000, 'h000000
-};
 
 wire [23:0] mem_data;
 
@@ -229,22 +120,13 @@ always @(posedge clk) begin
 	
 	if(pix_ce_n) begin
 		case (palette)
-			0: pixel <= pal_smooth_lut[color_ef][23:0];
-			1: pixel <= pal_unsat_lut[color_ef][23:0];
-			2: pixel <= pal_fcelut[color_ef][23:0];
-			3: pixel <= pal_nes_classic_lut[color_ef][23:0];
-			4: pixel <= pal_composite_direct_lut[color_ef][23:0];
-			5: pixel <= pal_pc10_lut[color_ef][23:0];
-			6: pixel <= pal_pvm_lut[color_ef][23:0];
-			7: pixel <= pal_wavebeam_lut[color_ef][23:0];
-			8: pixel <= pal_real_lut[color_ef][23:0];
-			9: pixel <= pal_sonycxa_lut[color_ef][23:0];
-			10: pixel <= pal_yuv_lut[color_ef][23:0];
-			11: pixel <= pal_greyscale_lut[color_ef][23:0];
-			12: pixel <= pal_rockman9_lut[color_ef][23:0];
-			13: pixel <= pal_nintendulator_lut[color_ef][23:0];
-			14: pixel <= mem_data;
-			default:pixel <= pal_smooth_lut[color_ef][23:0];
+			0: pixel <= pal_kitrinx_lut[color_ef][23:0];
+			1: pixel <= pal_smooth_lut[color_ef][23:0];
+			2: pixel <= pal_wavebeam_lut[color_ef][23:0];
+			3: pixel <= pal_sonycxa_lut[color_ef][23:0];
+			4: pixel <= pal_pc10_lut[color_ef][23:0];
+			5: pixel <= mem_data;
+			default:pixel <= pal_kitrinx_lut[color_ef][23:0];
 		endcase
 	
 		hbl <= hblank;


### PR DESCRIPTION
Some menu cleanup:
-Since palettes can now be loaded, reduce the number and built-in selections to a more manageable level
-Remove boot3.rom custom palette loading in favor of FC option
-Default autosave to "on"