### PR TITLE
PPU Fix, Update mappers

### DIFF
--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -17,10 +17,10 @@
 
 module cart_top (
 	input             clk,
-	input             ce,
-	input             ppu_ce,
+	input             ce,             // M2
+	input             cpu_ce,         // CPU Phi1 clock (several mappers use m2 inverted)
+	input             paused,         // This indicates the core is paused so anything using the master clock won't get messed up
 	input             reset,
-	input      [19:0] ppuflags,       // Misc flags from PPU for MMC5 cheating
 	input      [63:0] flags,          // Misc flags from ines header {prg_size(3), chr_size(3), mapper(8)}
 	input      [15:0] prg_ain,        // Better known as "CPU Address in"
 	output reg [24:0] prg_aout,       // PRG Input / Output Address Lines ([25:22] extended Lines [Misc ROM])
@@ -276,7 +276,7 @@ Mapper32 map32(
 //*****************************************************************************//
 MMC2 mmc2(
 	.clk        (clk),
-	.ce         (ppu_ce), // PPU_CE
+	.ce         (ce),
 	.enable     (me[9]),
 	.flags      (flags),
 	.prg_ain    (prg_ain),
@@ -298,6 +298,7 @@ MMC2 mmc2(
 	.audio_b    (audio_out_b),
 	// Special ports
 	.chr_ain_o  (chr_ain_orig),
+	.paused     (paused),
 	// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ), 
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
@@ -321,7 +322,7 @@ wire mmc3_en = me[118] | me[119] | me[47] | me[206] | me[112] | me[88] | me[154]
 
 MMC3 mmc3 (
 	.clk        (clk),
-	.ce         (ppu_ce), // PPU CE
+	.ce         (ce),
 	.enable     (mmc3_en),
 	.flags      (flags),
 	.prg_ain    (prg_ain),
@@ -343,6 +344,8 @@ MMC3 mmc3 (
 	.audio_b    (audio_out_b),
 	// Special ports
 	.chr_ain_o  (chr_ain_orig),
+	.m2_inv     (cpu_ce),
+	.paused     (paused),
 	// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ), 
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
@@ -361,7 +364,7 @@ MMC3 mmc3 (
 //*****************************************************************************//
 MMC4 mmc4(
 	.clk        (clk),
-	.ce         (ppu_ce), // PPU_CE
+	.ce         (ce),
 	.enable     (me[10]),
 	.flags      (flags),
 	.prg_ain    (prg_ain),
@@ -383,6 +386,7 @@ MMC4 mmc4(
 	.audio_b    (audio_out_b),
 	// Special ports
 	.chr_ain_o  (chr_ain_orig),
+	.paused     (paused),
 	// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ), 
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
@@ -427,7 +431,7 @@ MMC5 mmc5(
 	.chr_din    (chr_din),
 	.chr_write  (chr_write),
 	.chr_dout_b (chr_dout_b),
-	.ppu_ce     (ppu_ce),
+	.paused     (paused),
 		// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ), 
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
@@ -1220,7 +1224,7 @@ Mapper111 map111(
 //*****************************************************************************//
 Mapper165 map165(
 	.clk        (clk),
-	.ce         (ppu_ce), // PPU_CE
+	.ce         (ce),
 	.enable     (me[165]),
 	.flags      (flags),
 	.prg_ain    (prg_ain),
@@ -1241,7 +1245,9 @@ Mapper165 map165(
 	.audio_in   (audio_in),
 	.audio_b    (audio_out_b),
 	// Special ports
-	.chr_ain_o  (chr_ain_orig)
+	.chr_ain_o  (chr_ain_orig),
+	.m2_inv     (cpu_ce),
+	.paused     (paused)
 );
 
 //*****************************************************************************//
@@ -1622,7 +1628,7 @@ VRC5 vrc5(
 	.chr_din    (chr_din),
 	.chr_write  (chr_write),
 	.chr_dout_b (chr_dout_b),
-	.ppu_ce     (ppu_ce),
+	.paused     (paused),
 	// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ), 
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
@@ -1809,8 +1815,7 @@ Nanjing map163(
 	.audio_in   (audio_in),
 	.audio_b    (audio_out_b),
 	// Special Ports
-	.ppu_ce     (ppu_ce),
-	.ppuflags   (ppuflags)
+	.paused     (paused)
 );
 
 
@@ -1987,7 +1992,7 @@ JYCompany jycompany(
 	.audio_in   (audio_in),
 	.audio_b    (audio_out_b),
 	// Special ports
-	.ppu_ce     (ppu_ce),
+	.paused     (paused),
 	.chr_ain_o  (chr_ain_orig),
 	// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ), 
@@ -2074,7 +2079,7 @@ Mapper225 map225(
 //*****************************************************************************//
 Mapper413 map413 (
 	.clk        (clk),
-	.ce         (ppu_ce), // PPU CE
+	.ce         (ce),
 	.enable     (me[413]),
 	.flags      (flags),
 	.prg_ain    (prg_ain),
@@ -2096,7 +2101,9 @@ Mapper413 map413 (
 	.audio_b    (audio_out_b),
 	// Special ports
 	.chr_ain_o  (chr_ain_orig),
-	.prg_aoute  (prg_aoute_m413)
+	.prg_aoute  (prg_aoute_m413),
+	.m2_inv     (cpu_ce),
+	.paused     (paused)
 );
 
 //*****************************************************************************//

--- a/rtl/mappers/MMC2.sv
+++ b/rtl/mappers/MMC2.sv
@@ -24,6 +24,7 @@ module MMC2(
 	inout [15:0] audio_b,     // Mixed audio output
 	inout [15:0] flags_out_b, // flags {0, 0, 0, 0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout}
 	input [13:0] chr_ain_o,
+	input        paused,
 	// savestates              
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
@@ -140,7 +141,7 @@ if (~enable) begin
 end else if (SaveStateBus_load) begin
 	latch_0 <= SS_MAP1[   25];
 	latch_1 <= SS_MAP1[   26];
-end else if (ce && chr_read) begin
+end else if (~paused && chr_read) begin
 	latch_0 <= (chr_ain_o & 14'h3fff) == 14'h0fd8 ? 1'd0 : (chr_ain_o & 14'h3fff) == 14'h0fe8 ? 1'd1 : latch_0;
 	latch_1 <= (chr_ain_o & 14'h3ff8) == 14'h1fd8 ? 1'd0 : (chr_ain_o & 14'h3ff8) == 14'h1fe8 ? 1'd1 : latch_1;
 end
@@ -220,6 +221,7 @@ module MMC4(
 	inout [15:0] audio_b,     // Mixed audio output
 	inout [15:0] flags_out_b, // flags {0, 0, 0, 0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout}
 	input [13:0] chr_ain_o,
+	input        paused,
 	// savestates              
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
@@ -334,7 +336,7 @@ always @(posedge clk)
 if (SaveStateBus_load) begin
 	latch_0 <= SS_MAP1[   25];
 	latch_1 <= SS_MAP1[   26];
-end else if (ce & chr_read) begin
+end else if (~paused & chr_read) begin
 	latch_0 <= (chr_ain_o & 14'h3ff8) == 14'h0fd8 ? 1'd0 : (chr_ain_o & 14'h3ff8) == 14'h0fe8 ? 1'd1 : latch_0;
 	latch_1 <= (chr_ain_o & 14'h3ff8) == 14'h1fd8 ? 1'd0 : (chr_ain_o & 14'h3ff8) == 14'h1fe8 ? 1'd1 : latch_1;
 end

--- a/rtl/mappers/MMC5.sv
+++ b/rtl/mappers/MMC5.sv
@@ -28,7 +28,7 @@ module MMC5(
 	input  [7:0] chr_din,     // CHR Data in
 	input        chr_write,   // CHR Write
 	inout  [7:0] chr_dout_b,  // chr data (non standard)
-	input        ppu_ce,
+	input        paused,
 	// savestates              
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
@@ -217,7 +217,7 @@ always @(posedge clk) begin
 	// Mode 2 - Readable and writable
 	// Mode 3 - Read-only
 	if (extended_ram_mode != 3) begin
-		if (ppu_ce && !ppu_in_frame && !extended_ram_mode[1] && chr_write && (mirrbits == 2) && chr_ain[13]) begin
+		if (~paused && !ppu_in_frame && !extended_ram_mode[1] && chr_write && (mirrbits == 2) && chr_ain[13]) begin
 			ram_addrA <= chr_ain[9:0];
 			ram_dataA <= chr_din;
 			ram_wrenA <= 1'b1;

--- a/rtl/mappers/VRC.sv
+++ b/rtl/mappers/VRC.sv
@@ -1313,7 +1313,7 @@ module VRC5(
 	input  [7:0] chr_din,     // CHR Data in
 	input        chr_write,   // CHR Write
 	inout  [7:0] chr_dout_b,  // chr data (non standard)
-	input        ppu_ce,
+	input        paused,
 	// savestates              
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
@@ -1439,7 +1439,7 @@ always @(posedge clk) begin
 		end
 	end
 
-	if (ppu_ce && chr_read && (chr_ain[13:12] == 2'b10) && (~&chr_ain[9:6])) begin
+	if (~paused && chr_read && (chr_ain[13:12] == 2'b10) && (~&chr_ain[9:6])) begin
 		qtram_read_addr <= {vram_a10,chr_ain[9:0]};
 	end
 end

--- a/rtl/nes.v
+++ b/rtl/nes.v
@@ -543,7 +543,6 @@ wire chr_read, chr_write, chr_read_ex;       // If PPU reads/writes from VRAM
 wire [13:0] chr_addr, chr_addr_ex;           // Address PPU accesses in VRAM
 wire [7:0] chr_from_ppu;        // Data from PPU to VRAM
 wire [7:0] chr_to_ppu;
-wire [19:0] mapper_ppu_flags;   // PPU flags for mapper cheating
 wire [8:0] ppu_cycle;
 wire [8:0] scanline_ppu;
 assign cycle = use_fake_h ? 9'd340 : (corepause_active) ? cycle_paused : ppu_cycle;
@@ -570,7 +569,6 @@ PPU ppu(
 	.vram_dout        (chr_from_ppu),
 	.scanline         (scanline_ppu),
 	.cycle            (ppu_cycle),
-	.mapper_ppu_flags (mapper_ppu_flags),
 	.emphasis         (emphasis),
 	.short_frame      (skip_pixel),
 	.extra_sprites    (ex_sprites),
@@ -616,8 +614,10 @@ cart_top multi_mapper (
 	.clk               (clk),
 	.reset             (reset_noSS),
 	.flags             (mapper_flags),            // iNES header data (use 0 while loading)
+	.paused            (freeze_clocks),
 	// Cart pins (slightly abstracted)
 	.ce                (cart_ce & ~reset_noSS),   // M2 (held in high impedance during reset)
+	.cpu_ce            (cpu_ce),                  // Serves as M2 Inverted
 	.prg_ain           (prg_addr),                // CPU Address in (a15 abstracted from ROMSEL)
 	.prg_read          (prg_read),                // CPU RnW split
 	.prg_write         (prg_write),               // CPU RnW split
@@ -650,8 +650,6 @@ cart_top multi_mapper (
 	.mapper_ovr        (bram_override),
 	// Cheats
 	.prg_from_ram      (from_data_bus),           // Hacky cpu din <= get rid of this!
-	.ppuflags          (mapper_ppu_flags),        // Cheat for MMC5
-	.ppu_ce            (ppu_ce),                  // PPU Clock (cheat for MMC5/2/4)
 	// Behavior helper flags
 	.has_chr_dout      (has_chr_from_ppu_mapper), // Output specific data for CHR rather than from SDRAM
 	.prg_bus_write     (prg_bus_write),           // PRG data driven to bus

--- a/rtl/ppu.sv
+++ b/rtl/ppu.sv
@@ -78,7 +78,7 @@ always @(posedge clk) begin
 			end
 	
 			// Vertical Increment
-			if (cycle == 251) begin
+			if (cycle == 255) begin
 				loopy_v[14:12] <= loopy_v[14:12] + 1'd1;
 				if (loopy_v[14:12] == 7) begin
 					if (loopy_v[9:5] == 29) begin
@@ -1084,7 +1084,6 @@ module PPU(
 	output  [7:0] vram_dout,
 	output  [8:0] scanline,
 	output  [8:0] cycle,
-	output [19:0] mapper_ppu_flags,
 	output reg [2:0] emphasis,
 	output        short_frame,
 	input         extra_sprites,
@@ -1392,8 +1391,9 @@ always_comb begin
 			vram_r_ex = use_ex && extra_sprites;
 		else
 			vram_r_ex = 0;
-
-		if (cycle[2:1] == 0 || at_last_cycle_group)
+		if (cycle == 340)
+			vram_a = {1'b0, bg_patt, bg_name_table, cycle[1], loopy[14:12]}; // Pattern table override
+		else if (cycle[2:1] == 0 || at_last_cycle_group)
 			vram_a = {2'b10, loopy[11:0]};                                   // Name Table
 		else if (cycle[2:1] == 1)
 			vram_a = {2'b10, loopy[11:10], 4'b1111, loopy[9:7], loopy[4:2]}; // Attribute table
@@ -1610,8 +1610,5 @@ always @(posedge clk) begin
 end
 
 assign dout = latched_dout;
-
-
-assign mapper_ppu_flags = {scanline, cycle, obj_size, is_rendering};
 
 endmodule  // PPU

--- a/rtl/ppu.sv
+++ b/rtl/ppu.sv
@@ -78,7 +78,7 @@ always @(posedge clk) begin
 			end
 	
 			// Vertical Increment
-			if (cycle == 255) begin
+			if (cycle == 251) begin
 				loopy_v[14:12] <= loopy_v[14:12] + 1'd1;
 				if (loopy_v[14:12] == 7) begin
 					if (loopy_v[9:5] == 29) begin


### PR DESCRIPTION
This fixes the PPU to appropriately show the pattern table address as the vram address during the unused cycle 340. This is important for the MMC3 mapper to use the real inverted M2 timings as seen in the decapped chip schematics from furrtek. This fixes Wario's Woods while using the real timings. Also in this PR several of the cheat signals given to the mappers could now be removed.