### PR TITLE
Add Advanced Option to Disable Video Dejitter

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -212,7 +212,7 @@ end
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXX XX     XXXXXXXXXX XX XX XXXXXXXXXXXXXXXXXXXXXX
+// XXXXXXXX XX     XXXXXXXXXXXXX XX XXXXXXXXXXXXXXXXXXXXXX
 
 `include "build_id.v"
 parameter CONF_STR = {
@@ -265,6 +265,9 @@ parameter CONF_STR = {
 	"P3OG,Disk Swap,Auto,FDS button;",
 	"P3O[17],Disk Speed,Fast,Original;",
 	"P3o9,Pause when OSD is open,Off,On;",
+	"P4,Advanced;",
+	"P4-;",
+	"P4OQ,Video Dijitter,Enabled,Disabled;",
 	"- ;",
 	"R0,Reset;",
 	"J1,A,B,Select,Start,FDS,Mic,Zapper/Vaus Btn,PP/Mat 1,PP/Mat 2,PP/Mat 3,PP/Mat 4,PP/Mat 5,PP/Mat 6,PP/Mat 7,PP/Mat 8,PP/Mat 9,PP/Mat 10,PP/Mat 11,PP/Mat 12,Savestates;",
@@ -860,6 +863,7 @@ NES nes (
 	.cycle           (cycle),
 	.scanline        (scanline),
 	.mask            (status[28:27]),
+	.dejitter_timing(status[26]),
 	// User Input
 	.joypad_out      (joypad_out),
 	.joypad_clock    (joypad_clock),

--- a/rtl/nes.v
+++ b/rtl/nes.v
@@ -94,6 +94,7 @@ module NES(
 	input   [4:0] audio_channels, // Enabled audio channels
 	input         ex_sprites,
 	input   [1:0] mask,
+	input 		  dejitter_timing,
 
 	// Access signals for the SDRAM.
 	output [24:0] cpumem_addr,
@@ -295,7 +296,7 @@ always @(posedge clk) begin
 	if (|faux_pixel_cnt)
 		faux_pixel_cnt <= faux_pixel_cnt - 1'b1;
 
-	if (((skip_pixel && ~corepause_active) || (skip_pixel_pause && corepause_active)) && (faux_pixel_cnt == 0)) begin
+	if ((((skip_pixel && ~corepause_active) || (skip_pixel_pause && corepause_active)) && (faux_pixel_cnt == 0)) && !dejitter_timing) begin
 		freeze_clocks <= 1'b1;
 		faux_pixel_cnt <= {div_ppu_n - 1'b1, 1'b0} + 1'b1;
 	end


### PR DESCRIPTION
- Added option to disable video dejitter adjust video timing to meet original NES timing.  (Default is enabled)
- Note: This option only benefits those on Composite out, and may cause issues for those on HDMI or using scalars.