### PR TITLE
Implement KIL unofficial opcode

### DIFF
--- a/rtl/t65/T65.vhd
+++ b/rtl/t65/T65.vhd
@@ -774,7 +774,7 @@ begin
             elsif IRQ_n_o = '0' and P(Flag_I) = '0' then
               IRQCycle <= '1';
             end if;
-          else
+          elsif MCycle/="111" then -- increment machine cycle but do not overflow
             MCycle <= std_logic_vector(unsigned(MCycle) + 1);
           end if;
         end if;

--- a/rtl/t65/T65_MCode.vhd
+++ b/rtl/t65/T65_MCode.vhd
@@ -589,6 +589,7 @@ begin
               Jump <= "01";
             else
               -- KIL !!!
+              lCycle <= Cycle_sync; -- Prevents end-of-instruction signal, halting CPU
             end if;
           when others =>
         end case;


### PR DESCRIPTION
The KIL instruction now takes infinite cycles to execute, halting the CPU until a reset occurs. Resolves #379