### PR TITLE
Mapper 40 Support

### DIFF
--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -637,6 +637,37 @@ Mapper34 map34(
 );
 
 //*****************************************************************************//
+// Name   : NTDEC 2722                                                         //
+// Mappers: 40                                                                 //
+// Status : Working                                                            //
+// Notes  : Used for converted FDS carts.                                      //
+// Games  : Super Mario Bros. 2 (LF36)                                         //
+//*****************************************************************************//
+Mapper40 map40(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[40]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b)
+);
+
+//*****************************************************************************//
 // Name   : Mapper 41                                                          //
 // Mappers: 41                                                                 //
 // Status : Working                                                            //


### PR DESCRIPTION
Mapper used for bootleg releases of Super Mario Bros. 2 (J) to cartridge by companies such as Whirlwind Manu and Hey Sung. Submapper 1 (used by a multicart from NTDEC) is not supported currently.