### PR TITLE
several accuracy fixes (passes more tests on new test rom)

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -1339,7 +1339,7 @@ wire statusUpdate;
 
 //Ignore F1-F4 when famicom keyboard is enabled
 wire skip_ps2 = (ps2_key[7:0] == 'h04) || (ps2_key[7:0] == 'h05) || (ps2_key[7:0] == 'h06) || (ps2_key[7:0] == 'h0C);
-wire [10:0] ps2_key_adjust = skip_ps2 && fkeyb ? 'h0 : ps2_key[10:0];
+wire [10:0] ps2_key_adjust = skip_ps2 && fkeyb ? 11'h0 : ps2_key[10:0];
 
 savestate_ui savestate_ui
 (

--- a/rtl/apu.sv
+++ b/rtl/apu.sv
@@ -130,7 +130,7 @@ module SquareChan (
 	input  logic [7:0] lc_load,
 	input  logic       LenCtr_Clock,
 	input  logic       Env_Clock,
-	input  logic       odd_or_even,
+	input  logic       get_or_put,
 	input  logic       Enabled,
 	output logic [3:0] Sample,
 	output logic       IsNonZero
@@ -500,7 +500,7 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 	output logic  [6:0] Sample,
 	output logic        dma_req,      // 1 when DMC wants DMA
 	output logic        enable,
-	// savestates              
+	// savestates
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
 	input               SaveStateBus_wren,
@@ -508,6 +508,13 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 	input               SaveStateBus_load,
 	output      [63:0]  SaveStateBus_Dout
 );
+	// NOTE: Implicit DMA abort behavior is intentionally not emulated. I consider this undersireable
+	// behavior as the bug appeared so very late in the consoles lifespan. This is the note from the
+	// nesdev wiki: On RP2A03H and late RP2A03G CPUs, when playback is stopped implicitly on the same
+	// APU cycle that a reload DMA would schedule (that is, the 1st CPU cycle before the halt attempt),
+	// an unexpected reload DMA occurs from the same address. This extra byte goes into the sample
+	// buffer and is played after the first byte, as with any normal fetch. On RP2A03G CPUs, this bug
+	// was introduced sometime in 1990; earlier chips are unaffected.
 
 	// Savestates
 	localparam SAVESTATE_MODULES    = 2;
@@ -515,11 +522,11 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 	assign SaveStateBus_Dout = SaveStateBus_wired_or[0] | SaveStateBus_wired_or[1];
 
 	wire [63:0] SS_DMC1;
-	wire [63:0] SS_DMC1_BACK;	
+	wire [63:0] SS_DMC1_BACK;
 	wire [63:0] SS_DMC2;
 	wire [63:0] SS_DMC2_BACK;
-	eReg_SavestateV #(SSREG_INDEX_DMC1, SSREG_DEFAULT_APU_DMC1) iREG_SAVESTATE_APU_DMC1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_DMC1_BACK, SS_DMC1);  
-	eReg_SavestateV #(SSREG_INDEX_DMC2, SSREG_DEFAULT_APU_DMC2) iREG_SAVESTATE_APU_DMC2 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[1], SS_DMC2_BACK, SS_DMC2);  
+	eReg_SavestateV #(SSREG_INDEX_DMC1, SSREG_DEFAULT_APU_DMC1) iREG_SAVESTATE_APU_DMC1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_DMC1_BACK, SS_DMC1);
+	eReg_SavestateV #(SSREG_INDEX_DMC2, SSREG_DEFAULT_APU_DMC2) iREG_SAVESTATE_APU_DMC2 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[1], SS_DMC2_BACK, SS_DMC2);
 
 	logic irq_enable;
 	logic loop;                 // Looping enabled
@@ -554,7 +561,7 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 	};
 
 	assign Sample = dmc_volume_next[6:0];
-	assign dma_req = ~have_buffer & enable & enable_3;
+	assign dma_req = ~have_buffer & enable_3;
 	logic dmc_clock;
 
 	assign dma_address[15] = 1;
@@ -590,7 +597,7 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 			endcase
 		end
 
-		if (aclk1_d) begin
+		if (aclk1_d) begin // Put cycle
 			enable_1 <= enable;
 			enable_2 <= enable_1;
 			dmc_lsfr <= {dmc_lsfr[7:0], (dmc_lsfr[8] ^ dmc_lsfr[4]) | ~|dmc_lsfr};
@@ -639,7 +646,7 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 
 		// Volume adjustment is done on aclk1. Technically, the value written to 4011 is immediately
 		// applied, but won't "stick" if it conflicts with a lsfr clocked do-adjust.
-		if (aclk1) begin
+		if (aclk1) begin // Get cycle
 			enable_1 <= enable;
 			enable_3 <= enable_2;
 
@@ -650,7 +657,7 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 			end
 		end
 
-	   if (reset) begin
+		if (reset) begin
 			irq                     <= SS_DMC1[    0]; // 0;
 			dmc_volume              <= SS_DMC1[ 8: 1]; // {7'h0, dmc_volume[0]};
 			dmc_volume_next         <= SS_DMC1[16: 9]; // {7'h0, dmc_volume[0]};
@@ -690,21 +697,21 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 		end
 
 	end
-	
-	assign SS_DMC1_BACK[    0] = irq;            
-	assign SS_DMC1_BACK[ 8: 1] = dmc_volume;     
+
+	assign SS_DMC1_BACK[    0] = irq;
+	assign SS_DMC1_BACK[ 8: 1] = dmc_volume;
 	assign SS_DMC1_BACK[16: 9] = dmc_volume_next;
-	assign SS_DMC1_BACK[24:17] = sample_shift;   
+	assign SS_DMC1_BACK[24:17] = sample_shift;
 	assign SS_DMC1_BACK[36:25] = bytes_remaining;
-	assign SS_DMC1_BACK[39:37] = dmc_bits;       
-	assign SS_DMC1_BACK[47:40] = sample_buffer;  
-	assign SS_DMC1_BACK[   48] = have_buffer;    
-	assign SS_DMC1_BACK[   49] = enable;         
-	assign SS_DMC1_BACK[   50] = enable_1;       
-	assign SS_DMC1_BACK[   51] = enable_2;       
-	assign SS_DMC1_BACK[   52] = enable_3;       
+	assign SS_DMC1_BACK[39:37] = dmc_bits;
+	assign SS_DMC1_BACK[47:40] = sample_buffer;
+	assign SS_DMC1_BACK[   48] = have_buffer;
+	assign SS_DMC1_BACK[   49] = enable;
+	assign SS_DMC1_BACK[   50] = enable_1;
+	assign SS_DMC1_BACK[   51] = enable_2;
+	assign SS_DMC1_BACK[   52] = enable_3;
 	assign SS_DMC1_BACK[63:53] = 11'b0; // free to be used
-	
+
 	assign SS_DMC2_BACK[14: 0] = dma_address[14:0];
 	assign SS_DMC2_BACK[23:15] = dmc_lsfr;
 	assign SS_DMC2_BACK[   24] = loop;
@@ -715,7 +722,7 @@ module DmcChan #(parameter [9:0] SSREG_INDEX_DMC1, parameter [9:0] SSREG_INDEX_D
 	assign SS_DMC2_BACK[   46] = dmc_clock;
 	assign SS_DMC2_BACK[   47] = dmc_silence;
 	assign SS_DMC2_BACK[63:48] = 16'b0; // free to be used
-	
+
 endmodule
 
 module FrameCtr #(parameter [9:0] SSREG_INDEX_FCT) (
@@ -735,7 +742,7 @@ module FrameCtr #(parameter [9:0] SSREG_INDEX_FCT) (
 	output logic irq_flag,
 	output logic frame_half,
 	output logic frame_quarter,
-	// savestates              
+	// savestates
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
 	input               SaveStateBus_wren,
@@ -746,8 +753,8 @@ module FrameCtr #(parameter [9:0] SSREG_INDEX_FCT) (
 
 	// Savestates
 	wire [63:0] SS_FCT;
-	wire [63:0] SS_FCT_BACK;	
-	eReg_SavestateV #(SSREG_INDEX_FCT, SSREG_DEFAULT_APU_FCT) iREG_SAVESTATE_APU_FCT (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_Dout, SS_FCT_BACK, SS_FCT);  
+	wire [63:0] SS_FCT_BACK;
+	eReg_SavestateV #(SSREG_INDEX_FCT, SSREG_DEFAULT_APU_FCT) iREG_SAVESTATE_APU_FCT (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_Dout, SS_FCT_BACK, SS_FCT);
 
 	// NTSC -- Confirmed
 	// Binary Frame Value         Decimal  Cycle
@@ -802,30 +809,44 @@ module FrameCtr #(parameter [9:0] SSREG_INDEX_FCT) (
 	assign frame_half = (frm_b | frm_d | frm_e | (w4017_2 & seq_mode));
 	assign frame_quarter = (frm_a | frm_b | frm_c | frm_d | frm_e | (w4017_2 & seq_mode));
 
-	always_ff @(posedge clk) begin : apu_block
+	logic frame_interrupt_clear_pending;
 
-		if (aclk1) begin
+	always_ff @(posedge clk) begin : apu_block
+		if (addr == 2'h1 && read)
+			FrameInterrupt <= 0;
+
+		if (set_irq) begin
+			FrameInterrupt <= 1;
+			frame_interrupt_buffer <= 1;
+		end
+
+		if (aclk1) begin // Get cycle
 			frame <= frame_reset_2 ? 15'h7FFF : {frame[13:0], ((frame[14] ^ frame[13]) | ~|frame)};
 			w4017_2 <= w4017_1;
 			w4017_1 <= 0;
 			FrameSeqMode_2 <= FrameSeqMode;
 			frame_reset_2 <= 0;
+			if (~FrameInterrupt) frame_interrupt_buffer <= 0;
 		end
 
 		if (aclk2 & frame_reset)
 			frame_reset_2 <= 1;
 
-		// Continously update the Frame IRQ state and read buffer
-		if (set_irq & ~frame_int_disabled) begin
-			FrameInterrupt <= 1;
-			frame_interrupt_buffer <= 1;
-		end else if (addr == 2'h1 && read)
-			FrameInterrupt <= 0;
-		else
-			frame_interrupt_buffer <= FrameInterrupt;
+		// Setting the IRQ will trump clearing the IRQ, so it must be set cleared above where it
+		// is set.
 
-		if (frame_int_disabled)
+
+
+
+		if (frame_int_disabled) begin
 			FrameInterrupt <= 0;
+		end
+
+
+		// else
+		// 	frame_interrupt_buffer <= FrameInterrupt;
+
+
 
 		if (write_ce && addr == 3 && ~MMC5) begin  // Register $4017
 			FrameSeqMode <= din[7];
@@ -851,12 +872,12 @@ module FrameCtr #(parameter [9:0] SSREG_INDEX_FCT) (
 			end
 		end
 	end
-	
-	assign SS_FCT_BACK[14: 0] = frame;                 
-	assign SS_FCT_BACK[   15] = FrameInterrupt;        
+
+	assign SS_FCT_BACK[14: 0] = frame;
+	assign SS_FCT_BACK[   15] = FrameInterrupt;
 	assign SS_FCT_BACK[   16] = frame_interrupt_buffer;
-	assign SS_FCT_BACK[   17] = w4017_1;               
-	assign SS_FCT_BACK[   18] = w4017_2;               
+	assign SS_FCT_BACK[   17] = w4017_1;
+	assign SS_FCT_BACK[   18] = w4017_2;
 	assign SS_FCT_BACK[   19] = DisableFrameInterrupt;
 	assign SS_FCT_BACK[   20] = FrameSeqMode;
 	assign SS_FCT_BACK[   21] = FrameSeqMode_2;
@@ -881,14 +902,16 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 	input  logic        CS,
 	input  logic  [4:0] audio_channels, // Enabled audio channels
 	input  logic  [7:0] DmaData,        // Input data to DMC from memory.
-	input  logic        odd_or_even,
+	input  logic        get_or_put,
 	input  logic        DmaAck,         // 1 when DMC byte is on DmcData. DmcDmaRequested should go low.
 	output logic  [7:0] DOUT,           // Data from APU
 	output logic [15:0] Sample,
 	output logic        DmaReq,         // 1 when DMC wants DMA
 	output logic [15:0] DmaAddr,        // Address DMC wants to read
 	output logic        IRQ,            // IRQ asserted high == asserted
-	// savestates              
+	output logic        get_ce,         // Clock enable for a get cycle
+	output logic        put_ce,         // Clock enable for a put cycle
+	// savestates
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
 	input               SaveStateBus_wren,
@@ -902,10 +925,10 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 	localparam SAVESTATE_MODULES    = 3;
 	wire [63:0] SaveStateBus_wired_or[0:SAVESTATE_MODULES-1];
 	assign SaveStateBus_Dout = SaveStateBus_wired_or[0] | SaveStateBus_wired_or[1] | SaveStateBus_wired_or[2];
-	
+
 	wire [63:0] SS_APU;
 	wire [63:0] SS_APU_BACK;
-	eReg_SavestateV #(SSREG_INDEX_TOP, SSREG_DEFAULT_APU_TOP) iREG_SAVESTATE_APU_TOP (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_APU_BACK, SS_APU);  
+	eReg_SavestateV #(SSREG_INDEX_TOP, SSREG_DEFAULT_APU_TOP) iREG_SAVESTATE_APU_TOP (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_APU_BACK, SS_APU);
 
 
 	logic [7:0] len_counter_lut[32];
@@ -939,10 +962,13 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 	// aclk2    -- Aligned with CPU phi2, also every other frame
 	// write    -- Happens on CPU phi2 (Not M2!). Most of these are latched by one of the above clocks.
 	logic aclk1, aclk2, aclk1_delayed, phi1;
-	assign aclk1 = ce & odd_or_even;          // Defined as the cpu tick when the frame counter increases
-	assign aclk2 = phi2_ce & ~odd_or_even;                   // Tick on odd cycles, not 50% duty cycle so it covers 2 cpu cycles
-	assign aclk1_delayed = ce & ~odd_or_even; // Ticks 1 cpu cycle after frame counter
+	assign aclk1 = ce & get_or_put;          // Defined as the cpu tick when the frame counter increases
+	assign aclk2 = phi2_ce & ~get_or_put;    // Tick on odd cycles, not 50% duty cycle so it covers 2 cpu cycles
+	assign aclk1_delayed = ce & ~get_or_put; // Ticks 1 cpu cycle after frame counter
 	assign phi1 = ce;
+
+	assign get_ce = aclk1;
+	assign put_ce = aclk1_delayed;
 
 	logic [4:0] Enabled;
 	logic [3:0] Sq1Sample,Sq2Sample,TriSample,NoiSample;
@@ -959,7 +985,7 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 	assign ApuMW1 = ADDR[4:2]==1; // SQ2
 	assign ApuMW2 = ADDR[4:2]==2; // TRI
 	assign ApuMW3 = ADDR[4:2]==3; // NOI
-	assign ApuMW4 = ADDR[4:2]>=4; // DMC
+	assign ApuMW4 = ADDR[4:2]==4 || ADDR[4:0]==5'b10101; // DMC
 	assign ApuMW5 = ADDR[4:2]==5; // Control registers
 
 	logic Sq1NonZero, Sq2NonZero, TriNonZero, NoiNonZero;
@@ -1018,7 +1044,7 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 		.lc_load      (lc_load),
 		.LenCtr_Clock (ClkL),
 		.Env_Clock    (ClkE),
-		.odd_or_even  (odd_or_even),
+		.get_or_put   (get_or_put),
 		.Enabled      (Enabled[0]),
 		.Sample       (Sq1Sample),
 		.IsNonZero    (Sq1NonZero)
@@ -1039,7 +1065,7 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 		.lc_load      (lc_load),
 		.LenCtr_Clock (ClkL),
 		.Env_Clock    (ClkE),
-		.odd_or_even  (odd_or_even),
+		.get_or_put   (get_or_put),
 		.Enabled      (Enabled[1]),
 		.Sample       (Sq2Sample),
 		.IsNonZero    (Sq2NonZero)
@@ -1102,7 +1128,7 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 		.dma_req     (DmaReq),
 		.enable      (IsDmcActive),
 		// savestates
-		.SaveStateBus_Din  (SaveStateBus_Din ), 
+		.SaveStateBus_Din  (SaveStateBus_Din ),
 		.SaveStateBus_Adr  (SaveStateBus_Adr ),
 		.SaveStateBus_wren (SaveStateBus_wren),
 		.SaveStateBus_rst  (SaveStateBus_rst ),
@@ -1139,7 +1165,7 @@ module APU #(parameter [9:0] SSREG_INDEX_TOP, parameter [9:0] SSREG_INDEX_DMC1, 
 		.frame_half   (frame_half),
 		.frame_quarter(frame_quarter),
 		// savestates
-		.SaveStateBus_Din  (SaveStateBus_Din ), 
+		.SaveStateBus_Din  (SaveStateBus_Din ),
 		.SaveStateBus_Adr  (SaveStateBus_Adr ),
 		.SaveStateBus_wren (SaveStateBus_wren),
 		.SaveStateBus_rst  (SaveStateBus_rst ),

--- a/rtl/mappers/MMC5.sv
+++ b/rtl/mappers/MMC5.sv
@@ -30,18 +30,18 @@ module MMC5(
 	input        chr_write,   // CHR Write
 	inout  [7:0] chr_dout_b,  // chr data (non standard)
 	input        paused,
-	// savestates              
+	// savestates
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
 	input               SaveStateBus_wren,
 	input               SaveStateBus_rst,
 	input               SaveStateBus_load,
 	output      [63:0]  SaveStateBus_Dout,
-	
-	input         Savestate_MAPRAMactive, 
-	input  [9:0]  Savestate_MAPRAMAddr,     
-	input         Savestate_MAPRAMRdEn,    
-	input         Savestate_MAPRAMWrEn,    
+
+	input         Savestate_MAPRAMactive,
+	input  [9:0]  Savestate_MAPRAMAddr,
+	input         Savestate_MAPRAMRdEn,
+	input         Savestate_MAPRAMWrEn,
 	input  [7:0]  Savestate_MAPRAMWriteData,
 	output [7:0]  Savestate_MAPRAMReadData
 );
@@ -234,7 +234,7 @@ always @(posedge clk) begin
 		prg_bank_3 <= 7'h7F;
 		prg_mode <= 3;
 	end
-	
+
 	if (SaveStateBus_load) begin
 		prg_mode            <= SS_MAP1[ 1: 0];
 		chr_mode            <= SS_MAP1[ 3: 2];
@@ -298,7 +298,7 @@ assign SS_MAP2_BACK[39:30] = chr_bank_3;
 assign SS_MAP2_BACK[49:40] = chr_bank_4;
 assign SS_MAP2_BACK[59:50] = chr_bank_5;
 assign SS_MAP2_BACK[63:60] = 4'b0; // free to be used
-				  
+
 assign SS_MAP3_BACK[ 9: 0] = chr_bank_6;
 assign SS_MAP3_BACK[19:10] = chr_bank_7;
 assign SS_MAP3_BACK[29:20] = chr_bank_8;
@@ -306,7 +306,7 @@ assign SS_MAP3_BACK[39:30] = chr_bank_9;
 assign SS_MAP3_BACK[49:40] = chr_bank_a;
 assign SS_MAP3_BACK[59:50] = chr_bank_b;
 assign SS_MAP3_BACK[63:60] = 4'b0; // free to be used
-				  
+
 assign SS_MAP4_BACK[ 1: 0] = upper_chr_bank_bits;
 assign SS_MAP4_BACK[    2] = vsplit_enable;
 assign SS_MAP4_BACK[    3] = vsplit_side;
@@ -679,14 +679,14 @@ end
 localparam SAVESTATE_MODULES    = 5;
 wire [63:0] SaveStateBus_wired_or[0:SAVESTATE_MODULES-1];
 wire [63:0] SS_MAP1, SS_MAP2, SS_MAP3, SS_MAP4, SS_MAP5;
-wire [63:0] SS_MAP1_BACK, SS_MAP2_BACK, SS_MAP3_BACK, SS_MAP4_BACK, SS_MAP5_BACK;	
+wire [63:0] SS_MAP1_BACK, SS_MAP2_BACK, SS_MAP3_BACK, SS_MAP4_BACK, SS_MAP5_BACK;
 wire [63:0] SaveStateBus_Dout_active = SaveStateBus_wired_or[0] | SaveStateBus_wired_or[1] | SaveStateBus_wired_or[2] | SaveStateBus_wired_or[3] | SaveStateBus_wired_or[4];
-	
-eReg_SavestateV #(SSREG_INDEX_MAP1, 64'h0000000000000000) iREG_SAVESTATE_MAP1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_MAP1_BACK, SS_MAP1);  
-eReg_SavestateV #(SSREG_INDEX_MAP2, 64'h0000000000000000) iREG_SAVESTATE_MAP2 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[1], SS_MAP2_BACK, SS_MAP2);  
-eReg_SavestateV #(SSREG_INDEX_MAP3, 64'h0000000000000000) iREG_SAVESTATE_MAP3 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[2], SS_MAP3_BACK, SS_MAP3);  
-eReg_SavestateV #(SSREG_INDEX_MAP4, 64'h0000000000000000) iREG_SAVESTATE_MAP4 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[3], SS_MAP4_BACK, SS_MAP4);  
-eReg_SavestateV #(SSREG_INDEX_MAP5, 64'h0000000000000000) iREG_SAVESTATE_MAP5 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[4], SS_MAP5_BACK, SS_MAP5);  
+
+eReg_SavestateV #(SSREG_INDEX_MAP1, 64'h0000000000000000) iREG_SAVESTATE_MAP1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_MAP1_BACK, SS_MAP1);
+eReg_SavestateV #(SSREG_INDEX_MAP2, 64'h0000000000000000) iREG_SAVESTATE_MAP2 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[1], SS_MAP2_BACK, SS_MAP2);
+eReg_SavestateV #(SSREG_INDEX_MAP3, 64'h0000000000000000) iREG_SAVESTATE_MAP3 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[2], SS_MAP3_BACK, SS_MAP3);
+eReg_SavestateV #(SSREG_INDEX_MAP4, 64'h0000000000000000) iREG_SAVESTATE_MAP4 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[3], SS_MAP4_BACK, SS_MAP4);
+eReg_SavestateV #(SSREG_INDEX_MAP5, 64'h0000000000000000) iREG_SAVESTATE_MAP5 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[4], SS_MAP5_BACK, SS_MAP5);
 
 assign SaveStateBus_Dout = enable ? SaveStateBus_Dout_active : 64'h0000000000000000;
 
@@ -703,7 +703,7 @@ module mmc5_mixed (
 	output  [7:0] data_out,
 	input  [15:0] audio_in,    // Inverted audio from APU
 	output [15:0] audio_out,
-	// savestates              
+	// savestates
 	input       [63:0]  SaveStateBus_Din,
 	input       [ 9:0]  SaveStateBus_Adr,
 	input               SaveStateBus_wren,
@@ -730,7 +730,7 @@ always @(posedge clk) begin
 		odd_or_even <= 0;
 	else if (ce)
 		odd_or_even <= ~odd_or_even;
-		
+
 	if (SaveStateBus_load) begin
 		odd_or_even <= SS_MAP1[0];
 	end
@@ -756,10 +756,10 @@ APU mmc5apu(
 	.DmaAck         (1),
 	.DmaAddr        (DmaAddr),
 	.DmaData        (0),
-	.odd_or_even    (odd_or_even),
+	.get_or_put     (odd_or_even),
 	.IRQ            (apu_irq),
 	// savestates
-	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Din  (SaveStateBus_Din ),
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
 	.SaveStateBus_wren (SaveStateBus_wren),
 	.SaveStateBus_rst  (SaveStateBus_rst ),
@@ -775,10 +775,10 @@ defparam mmc5apu.SSREG_INDEX_FCT  = SSREG_INDEX_SNDMAP4;
 localparam SAVESTATE_MODULES    = 2;
 wire [63:0] SaveStateBus_wired_or[0:SAVESTATE_MODULES-1];
 wire [63:0] SS_MAP1;
-wire [63:0] SS_MAP1_BACK;	
+wire [63:0] SS_MAP1_BACK;
 wire [63:0] SaveStateBus_Dout_active = SaveStateBus_wired_or[0] | SaveStateBus_wired_or[1];
-	
-eReg_SavestateV #(SSREG_INDEX_SNDMAP5, 64'h0000000000000000) iREG_SAVESTATE_MAP1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_MAP1_BACK, SS_MAP1);  
+
+eReg_SavestateV #(SSREG_INDEX_SNDMAP5, 64'h0000000000000000) iREG_SAVESTATE_MAP1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_MAP1_BACK, SS_MAP1);
 
 assign SaveStateBus_Dout = enable ? SaveStateBus_Dout_active : 64'h0000000000000000;
 

--- a/rtl/nes.v
+++ b/rtl/nes.v
@@ -22,19 +22,22 @@ module DmaController(
 	input clk,
 	input ce,
 	input reset,
-	input odd_cycle,               // Current cycle even or odd?
+	input put_cycle,               // Current cycle even or odd?
+	input put_ce,                  // CE on a PUT cycle from APU
+	input get_ce,                  // CE on a GET cycle from APU
 	input sprite_trigger,          // Sprite DMA trigger?
 	input dmc_trigger,             // DMC DMA trigger?
 	input cpu_read,                // CPU is in a read cycle?
 	input [7:0] data_from_cpu,     // Data written by CPU?
-	input [7:0] data_from_ram,     // Data read from RAM?
+	input [7:0] dma_data_to_ram,     // Data read from RAM?
 	input [15:0] dmc_dma_addr,     // DMC DMA Address
 	output [15:0] aout,            // Address to access
 	output aout_enable,            // DMA controller wants bus control
 	output read,                   // 1 = read, 0 = write
 	output [7:0] data_to_ram,      // Value to write to RAM
 	output dmc_ack,                // ACK the DMC DMA
-	output pause_cpu               // CPU is pausede
+	output pause_cpu,              // CPU is paused
+	output [7:0] current_dbus      // The value of the current data bus
 );
 
 reg dmc_state;
@@ -49,23 +52,24 @@ always @(posedge clk) if (reset) begin
 	sprite_dma_lastval <= 0;
 	sprite_dma_addr <= 0;
 end else if (ce) begin
-	if (dmc_state == 0 && dmc_trigger && cpu_read && !odd_cycle) dmc_state <= 1;
-	if (dmc_state == 1 && !odd_cycle) dmc_state <= 0;
+	if (dmc_state == 0 && dmc_trigger && cpu_read && put_ce) dmc_state <= 1;
+	if (dmc_state == 1 && put_ce) dmc_state <= 0;
 
 	if (sprite_trigger) begin sprite_dma_addr <= {data_from_cpu, 8'h00}; spr_state <= 1; end
-	if (spr_state == 1 && cpu_read && odd_cycle) spr_state <= 3;
-	if (spr_state[1] && !odd_cycle && dmc_state == 1) spr_state <= 1;
-	if (spr_state[1] && odd_cycle) sprite_dma_addr[7:0] <= new_sprite_dma_addr[7:0];
-	if (spr_state[1] && odd_cycle && new_sprite_dma_addr[8]) spr_state <= 0;
-	if (spr_state[1]) sprite_dma_lastval <= data_from_ram;
+	if (spr_state == 1 && cpu_read && get_ce) spr_state <= 3;
+	if (spr_state[1] && put_ce && dmc_state == 1) spr_state <= 1;
+	if (spr_state[1] && get_ce) sprite_dma_addr[7:0] <= new_sprite_dma_addr[7:0];
+	if (spr_state[1] && get_ce && new_sprite_dma_addr[8]) spr_state <= 0;
+	if (spr_state[1]) sprite_dma_lastval <= dma_data_to_ram;
 end
 
-assign pause_cpu = (spr_state[0] || dmc_trigger);
-assign dmc_ack   = (dmc_state == 1 && !odd_cycle);
+assign pause_cpu = (spr_state[0] || dmc_trigger || dmc_state == 1);
+assign dmc_ack   = (dmc_state == 1 && !put_cycle && dmc_trigger); // a DMC hardware bug can make trigger fall before it's done
 assign aout_enable = dmc_ack || spr_state[1];
-assign read = !odd_cycle;
+assign read = !put_cycle;
 assign data_to_ram = sprite_dma_lastval;
-assign aout = dmc_ack ? dmc_dma_addr : !odd_cycle ? sprite_dma_addr : 16'h2004;
+assign aout = dmc_ack ? dmc_dma_addr : !put_cycle ? sprite_dma_addr : 16'h2004;
+assign current_dbus = !aout_enable ? dma_data_to_ram : (dmc_ack ? dma_data_to_ram : (!read ? data_to_ram : dma_data_to_ram));
 
 endmodule
 
@@ -130,7 +134,7 @@ module NES(
 	input         gg_reset,
 	output  [2:0] emphasis,
 	output        save_written,
-	
+
 	// savestates
 	output        mapper_has_savestate,
 	input         increaseSSHeaderCount,
@@ -139,17 +143,17 @@ module NES(
 	input  [1:0]  savestate_number,
 	output        sleep_savestate,
 	output        state_loaded,
-	
-	output [24:0] Savestate_SDRAMAddr,     
-	output        Savestate_SDRAMRdEn,    
-	output        Savestate_SDRAMWrEn,    
+
+	output [24:0] Savestate_SDRAMAddr,
+	output        Savestate_SDRAMRdEn,
+	output        Savestate_SDRAMWrEn,
 	output [7:0]  Savestate_SDRAMWriteData,
 	input  [7:0]  Savestate_SDRAMReadData,
-	
-	output [63:0] SaveStateExt_Din, 
-	output [9:0]  SaveStateExt_Adr, 
+
+	output [63:0] SaveStateExt_Din,
+	output [9:0]  SaveStateExt_Adr,
 	output        SaveStateExt_wren,
-	output        SaveStateExt_rst, 
+	output        SaveStateExt_rst,
 	input  [63:0] SaveStateExt_Dout,
 	output        SaveStateExt_load,
 
@@ -158,7 +162,7 @@ module NES(
 	output [25:0] SAVE_out_Adr,  	// all addresses are DWORD addresses!
 	output        SAVE_out_rnw,   // read = 1, write = 0
 	output        SAVE_out_ena,   // one cycle high for each action
-	output  [7:0] SAVE_out_be,     
+	output  [7:0] SAVE_out_be,
 	input         SAVE_out_done   // should be one cycle high when write is done or read value is valid
 );
 
@@ -320,10 +324,10 @@ always @(posedge clk) begin
 		div_sys <= 0;
 		cpu_tick_count <= 0;
 	end
-	
+
 	// pause
 	if (ppu_ce_pause) skip_pause_ce <= 0; // must skip the first CE after pause to sync back to correct ppu
-	
+
 	if (reset_nes) begin
 		corepause_active       <= 0;
 		corepause_active_delay <= 0;
@@ -336,15 +340,15 @@ always @(posedge clk) begin
 			corepause_active  <= 1;
 			div_ppu_pause     <= div_ppu + 3'd1;
 		end
-		
+
 		if (corepause_active) begin
-			
+
 			if (corepause_delay < 8'hFF) begin
 				corepause_delay <= corepause_delay + 1'd1;
 			end else begin
 				corepause_active_delay <= 1;
 			end
-			
+
 			if (~freeze_clocks | ~(div_ppu_pause == (div_ppu_n - 1'b1))) begin
 				div_ppu_pause <= ppu_ce_pause ? 3'd1 : div_ppu_pause + 3'd1;
 				if (~pausecore && ppu_ce_pause && (cycle_paused == ppu_cycle) && (scanline_paused == scanline_ppu) && (evenframe == evenframe_paused)) begin
@@ -357,7 +361,7 @@ always @(posedge clk) begin
 			corepause_delay <= 8'd0;
 		end
 	end
-	
+
 end
 
 assign SS_TOP_BACK[0] = odd_or_even;
@@ -385,6 +389,11 @@ ClockGen clockgen_pause(
 /*************              CPU             ***************/
 /**********************************************************/
 
+// TODO: At some point the CPU, APU, and DMA need to be isolated into their own unit, as in the
+// actual system they were part of the same package and the internal bus was isolated in a variety
+// of ways from the external bus. This is represented here in the code, but in a way that is pretty
+// unintuitive to anyone who looks at it.
+
 wire [15:0] cpu_addr;
 wire cpu_rnw;
 wire pause_cpu;
@@ -392,10 +401,11 @@ wire nmi;
 wire mapper_irq;
 wire apu_irq;
 wire cpu_Instrnew;
-
-// IRQ only changes once per CPU ce and with our current
-// limited CPU model, NMI is only latched on the falling edge
-// of M2, which corresponds with CPU ce, so no latches needed.
+// If the external bus is driven, electrically it will overwhelm the internal bus of register
+// 4015's output.
+wire apu_reg_cs = (apu_cs && addr[4:0] == 5'h15);
+wire [7:0] apu_reg_value = {apu_dout[7:6], from_data_bus[5], apu_dout[4:0]}; // Fill in the undriven bit with bus.
+wire [7:0] internal_data_bus = (apu_reg_cs ? apu_reg_value : from_data_bus);
 
 T65 cpu(
 	.mode   (0),
@@ -411,13 +421,13 @@ T65 cpu(
 	.R_W_n  (cpu_rnw),
 
 	.A      (cpu_addr),
-	.DI     (cpu_rnw ? from_data_bus : cpu_dout),
+	.DI     (cpu_rnw ? internal_data_bus : cpu_dout),
 	.DO     (cpu_dout),
-	
+
 	.Instrnew (cpu_Instrnew),
-	
+
 	// savestates
-	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Din  (SaveStateBus_Din ),
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
 	.SaveStateBus_wren (SaveStateBus_wren),
 	.SaveStateBus_rst  (SaveStateBus_rst ),
@@ -431,30 +441,38 @@ wire dma_read;
 wire [7:0] dma_data_to_ram;
 wire apu_dma_request, apu_dma_ack;
 wire [15:0] apu_dma_addr;
+wire [7:0] dma_dbus;
 
 // Determine the values on the bus outgoing from the CPU chip (after DMA / APU)
 wire [15:0] addr = dma_aout_enable ? dma_aout  : cpu_addr;
+wire [7:0] dma_data_bus = (joypad1_cs && dma_aout_enable) ? {from_data_bus[7:5], joypad1_data[4:0]} :
+	(joypad2_cs && dma_aout_enable) ? {from_data_bus[7:5], joypad2_data[4:0]} :
+	from_data_bus;
 wire [7:0]  dbus = dma_aout_enable ? dma_data_to_ram : cpu_dout;
 wire mr_int      = dma_aout_enable ? dma_read  : cpu_rnw;
 wire mw_int      = dma_aout_enable ? !dma_read : !cpu_rnw;
+wire get_ce, put_ce;
 
 DmaController dma(
 	.clk            (clk),
 	.ce             (cpu_ce),
 	.reset          (reset_noSS),
-	.odd_cycle      (odd_or_even),                // Even or odd cycle
+	.put_cycle      (odd_or_even),                // Even or odd cycle
 	.sprite_trigger ((addr == 'h4014 && mw_int)), // Sprite trigger
 	.dmc_trigger    (apu_dma_request),            // DMC Trigger
 	.cpu_read       (cpu_rnw),                    // CPU in a read cycle?
 	.data_from_cpu  (cpu_dout),                   // Data from cpu
-	.data_from_ram  (from_data_bus),              // Data from RAM etc.
+	.dma_data_to_ram  (internal_data_bus),              // Data from RAM etc.
 	.dmc_dma_addr   (apu_dma_addr),               // DMC addr
 	.aout           (dma_aout),
 	.aout_enable    (dma_aout_enable),
 	.read           (dma_read),
 	.data_to_ram    (dma_data_to_ram),
 	.dmc_ack        (apu_dma_ack),
-	.pause_cpu      (pause_cpu)
+	.pause_cpu      (pause_cpu),
+	.get_ce         (get_ce),
+	.put_ce         (put_ce),
+	.current_dbus	(dma_dbus)
 );
 
 
@@ -462,7 +480,8 @@ DmaController dma(
 /*************             APU              ***************/
 /**********************************************************/
 
-wire apu_cs = addr >= 'h4000 && addr < 'h4018;
+// The APU is part of the 2A03 and parts of it are not exposed to external busses.
+wire apu_cs = cpu_addr[15:5] == 11'b0100_0000_000;
 wire [7:0] apu_dout;
 wire [15:0] sample_apu;
 
@@ -484,11 +503,13 @@ APU apu(
 	.DmaReq         (apu_dma_request),
 	.DmaAck         (apu_dma_ack),
 	.DmaAddr        (apu_dma_addr),
-	.DmaData        (from_data_bus),
-	.odd_or_even    (odd_or_even),
+	.DmaData        (dma_data_bus),
+	.get_or_put     (odd_or_even),
 	.IRQ            (apu_irq),
+	.put_ce         (put_ce),
+	.get_ce         (get_ce),
 	// savestates
-	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Din  (SaveStateBus_Din ),
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
 	.SaveStateBus_wren (SaveStateBus_wren),
 	.SaveStateBus_rst  (SaveStateBus_rst ),
@@ -518,17 +539,21 @@ wire [15:0] audio_mappers = (audio_en == 2'd1) ? 16'd0 : sample_inverted;
 
 
 // Joypads are mapped into the APU's range.
-wire joypad1_cs = (addr == 'h4016);
-wire joypad2_cs = (addr == 'h4017);
+wire joypad1_cs = apu_cs && addr[4:0] == 5'h16;//(cpu_addr == 'h4016);
+wire joypad2_cs = apu_cs && addr[4:0] == 5'h17;//(cpu_addr == 'h4017);
 
 reg [2:0] joy_out;
+reg [2:0] joy_latch;
 always @(posedge clk) begin
-	if (joypad1_cs && mw_int)
-		joy_out <= cpu_dout[2:0];
+	if (put_ce) joy_out <= joy_latch;
+	if (joypad1_cs && ~cpu_rnw) begin
+		joy_latch <= cpu_dout[2:0];
+		if (put_ce) joy_out <= cpu_dout[2:0];
+	end
 end
 
 assign joypad_out = joy_out;
-assign joypad_clock = {joypad2_cs && mr_int, joypad1_cs && mr_int};
+assign joypad_clock = {joypad2_cs && cpu_rnw, joypad1_cs && cpu_rnw};
 
 
 /**********************************************************/
@@ -578,17 +603,17 @@ PPU ppu(
 	.extra_sprites    (ex_sprites),
 	.mask             (mask),
 	.render_ena_out   (render_ena),
-	.evenframe			(evenframe),
+	.evenframe        (evenframe),
 	// savestates
-	.SaveStateBus_Din       (SaveStateBus_Din        ), 
+	.SaveStateBus_Din       (SaveStateBus_Din        ),
 	.SaveStateBus_Adr       (SaveStateBus_Adr        ),
 	.SaveStateBus_wren      (SaveStateBus_wren       ),
 	.SaveStateBus_rst       (SaveStateBus_rst        ),
 	.SaveStateBus_load      (loading_savestate       ),
 	.SaveStateBus_Dout      (SaveStateBus_wired_or[2]),
-	.Savestate_OAMAddr      (Savestate_OAMAddr       ),     
-	.Savestate_OAMRdEn      (Savestate_OAMRdEn       ),    
-	.Savestate_OAMWrEn      (Savestate_OAMWrEn       ),    
+	.Savestate_OAMAddr      (Savestate_OAMAddr       ),
+	.Savestate_OAMRdEn      (Savestate_OAMRdEn       ),
+	.Savestate_OAMWrEn      (Savestate_OAMWrEn       ),
 	.Savestate_OAMWriteData (Savestate_OAMWriteData  ),
 	.Savestate_OAMReadData  (Savestate_OAMReadData   )
 );
@@ -601,7 +626,7 @@ PPU ppu(
 wire [15:0] prg_addr = addr;
 wire [7:0] prg_din = dbus & (prg_conflict ? cpumem_din : 8'hFF);
 
-wire prg_read  = mr_int && cart_pre && !apu_cs && !ppu_cs;
+wire prg_read  = mr_int && cart_pre && (addr[15:5] != 11'b0100_0000_000) && !ppu_cs;
 wire prg_write = mw_int && cart_pre;
 
 wire prg_allow, prg_bus_write, prg_conflict, vram_a10, vram_ce, chr_allow;
@@ -668,13 +693,13 @@ cart_top multi_mapper (
 	.fds_auto_eject    (fds_auto_eject),
 
 	// savestates
-	.SaveStateBus_Din  (SaveStateBus_Din ), 
+	.SaveStateBus_Din  (SaveStateBus_Din ),
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
 	.SaveStateBus_wren (SaveStateBus_wren),
 	.SaveStateBus_rst  (SaveStateBus_rst ),
 	.SaveStateBus_load (loading_savestate ),
 	.SaveStateBus_Dout (SaveStateBus_wired_or[3]),
-	
+
 	.Savestate_MAPRAMactive   (Savestate_MAPRAMactive),
 	.Savestate_MAPRAMAddr     (Savestate_MAPRAMAddr),
 	.Savestate_MAPRAMRdEn     (Savestate_MAPRAMRdEn),
@@ -720,37 +745,35 @@ always @(posedge clk) begin
 	if (loading_savestate) begin
 		open_bus_data <= SS_TOP[8:1];
 	end else begin
-		open_bus_data <= from_data_bus;
+		if (!cpu_ce)
+			open_bus_data <= mw_int ? dbus : dma_data_bus;
 	end
 end
 
-assign from_data_bus = genie_ovr ? genie_data : raw_data_bus;
+assign from_data_bus = genie_ovr ? genie_data : external_data_bus;
 
-reg [7:0] raw_data_bus;
+reg [7:0] external_data_bus;
 
 always @* begin
-	if (reset)
-		raw_data_bus = SS_TOP[16:9]; // 0;
-	else if (apu_cs) begin
-		if (joypad1_cs)
-			raw_data_bus = {open_bus_data[7:5], joypad1_data};
-		else if (joypad2_cs)
-			raw_data_bus = {open_bus_data[7:5], joypad2_data};
-		else
-			raw_data_bus = (addr == 16'h4015) ? apu_dout : open_bus_data;
-	end else if (ppu_cs) begin
-		raw_data_bus = ppu_dout;
-	end else if (prg_allow) begin
-		raw_data_bus = cpumem_din;
-	end else if (prg_bus_write) begin
-		raw_data_bus = prg_dout_mapper;
-	end else begin
-		raw_data_bus = open_bus_data;
+	if (reset) begin
+		external_data_bus = SS_TOP[16:9]; // 0;
+	end else if (joypad1_cs && ~dma_aout_enable) begin   // Joypad1 Read
+		external_data_bus = {open_bus_data[7:5], joypad1_data};
+	end else if (joypad2_cs && ~dma_aout_enable) begin   // Joypad2 Read
+		external_data_bus = {open_bus_data[7:5], joypad2_data};
+	end else if (ppu_cs) begin                          // PPU Read
+		external_data_bus = ppu_dout;
+	end else if (prg_allow) begin                       // PRG Read
+		external_data_bus = cpumem_din;
+	end else if (prg_bus_write) begin                   // PRG/CPU Write
+		external_data_bus = prg_dout_mapper;
+	end else begin                                      // Open Bus
+		external_data_bus = open_bus_data;
 	end
 end
 
 assign SS_TOP_BACK[ 8: 1] = open_bus_data;
-assign SS_TOP_BACK[16: 9] = raw_data_bus;
+assign SS_TOP_BACK[16: 9] = external_data_bus;
 assign SS_TOP_BACK[63:17] = 47'b0; // free to be used
 
 
@@ -761,7 +784,7 @@ assign SS_TOP_BACK[63:17] = 47'b0; // free to be used
 wire [63:0] SaveStateBus_Din;
 wire [9:0] SaveStateBus_Adr;
 wire SaveStateBus_wren, SaveStateBus_rst;
-  
+
 wire [7:0]  Savestate_RAMWriteData;
 wire [7:0]  Savestate_RAMReadData;
 wire [24:0] Savestate_RAMAddr;
@@ -777,14 +800,14 @@ wire reset_delay;
 wire savestate_savestate;
 wire savestate_loadstate;
 wire [31:0] savestate_address;
-wire savestate_busy;  
+wire savestate_busy;
 
 wire [63:0] SS_TOP;
-wire [63:0] SS_TOP_BACK;	
-eReg_SavestateV #(SSREG_INDEX_TOP, SSREG_DEFAULT_TOP) iREG_SAVESTATE_TOP (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[4], SS_TOP_BACK, SS_TOP);  
+wire [63:0] SS_TOP_BACK;
+eReg_SavestateV #(SSREG_INDEX_TOP, SSREG_DEFAULT_TOP) iREG_SAVESTATE_TOP (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[4], SS_TOP_BACK, SS_TOP);
 
 wire [63:0] SaveStateBus_Dout  = SaveStateBus_wired_or[0] | SaveStateBus_wired_or[1] | SaveStateBus_wired_or[2] | SaveStateBus_wired_or[3] | SaveStateBus_wired_or[4] | SaveStateExt_Dout;
- 
+
 wire loading_savestate;
 wire saving_savestate;
 wire sleep_savestates;
@@ -808,7 +831,7 @@ wire        Savestate_MAPRAMWrEn      = Savestate_RAMWrEn && (Savestate_RAMType 
 wire [7:0]  Savestate_MAPRAMWriteData = Savestate_RAMWriteData;
 wire [7:0]  Savestate_MAPRAMReadData;
 
-assign Savestate_RAMReadData = (Savestate_RAMType == 0) ? Savestate_OAMReadData : 
+assign Savestate_RAMReadData = (Savestate_RAMType == 0) ? Savestate_OAMReadData :
 										 (Savestate_RAMType == 1) ? Savestate_MAPRAMReadData :
 										 Savestate_SDRAMReadData;
 
@@ -818,67 +841,67 @@ assign SaveStateExt_wren = SaveStateBus_wren;
 assign SaveStateExt_rst  = SaveStateBus_rst;
 assign SaveStateExt_load = loading_savestate;
 
- 
+
 savestates savestates (
 	.clk                    (clk),
 	.reset_in               (reset_nes),
 	.reset_ss               (reset_ss),
 	.reset_delay            (reset_delay),
-	
+
 	.load_done              (state_loaded),
-	
+
 	.increaseSSHeaderCount  (increaseSSHeaderCount),
 	.save                   (savestate_savestate),
 	.load                   (savestate_loadstate),
 	.savestate_address      (savestate_address),
-	.savestate_busy         (savestate_busy),      
-	
+	.savestate_busy         (savestate_busy),
+
 	.paused                 (corepause_active_delay),
-	
-	.BUS_Din                (SaveStateBus_Din), 
-	.BUS_Adr                (SaveStateBus_Adr), 
-	.BUS_wren               (SaveStateBus_wren), 
-	.BUS_rst                (SaveStateBus_rst), 
+
+	.BUS_Din                (SaveStateBus_Din),
+	.BUS_Adr                (SaveStateBus_Adr),
+	.BUS_wren               (SaveStateBus_wren),
+	.BUS_rst                (SaveStateBus_rst),
 	.BUS_Dout               (SaveStateBus_Dout),
-		
+
 	.loading_savestate      (loading_savestate),
 	.saving_savestate       (saving_savestate),
 	.sleep_savestate        (sleep_savestates),
-	
-	.Save_RAMAddr           (Savestate_RAMAddr),     
-	.Save_RAMRdEn           (Savestate_RAMRdEn),           
-	.Save_RAMWrEn           (Savestate_RAMWrEn),           
-	.Save_RAMWriteData      (Savestate_RAMWriteData),   
+
+	.Save_RAMAddr           (Savestate_RAMAddr),
+	.Save_RAMRdEn           (Savestate_RAMRdEn),
+	.Save_RAMWrEn           (Savestate_RAMWrEn),
+	.Save_RAMWriteData      (Savestate_RAMWriteData),
 	.Save_RAMReadData       (Savestate_RAMReadData),
 	.Save_RAMType           (Savestate_RAMType),
-				
-	.bus_out_Din            (SAVE_out_Din),   
-	.bus_out_Dout           (SAVE_out_Dout),  
-	.bus_out_Adr            (SAVE_out_Adr),   
-	.bus_out_rnw            (SAVE_out_rnw),   
-	.bus_out_ena            (SAVE_out_ena),   
-	.bus_out_be             (SAVE_out_be),   
-	.bus_out_done           (SAVE_out_done)  
+
+	.bus_out_Din            (SAVE_out_Din),
+	.bus_out_Dout           (SAVE_out_Dout),
+	.bus_out_Adr            (SAVE_out_Adr),
+	.bus_out_rnw            (SAVE_out_rnw),
+	.bus_out_ena            (SAVE_out_ena),
+	.bus_out_be             (SAVE_out_be),
+	.bus_out_done           (SAVE_out_done)
 );
 
 statemanager #(58720256, 33554432) statemanager (
 	.clk                 (clk),
 	.reset               (reset_nes),
-	
-	.rewind_on           (1'b0),    
+
+	.rewind_on           (1'b0),
 	.rewind_active       (1'b0),
-	
+
 	.savestate_number    (savestate_number),
 	.save                (save_state),
 	.load                (load_state),
-	
+
 	.sleep_rewind        (sleep_rewind),
-	.vsync               (1'b0),       
-	
+	.vsync               (1'b0),
+
 	.request_savestate   (savestate_savestate),
 	.request_loadstate   (savestate_loadstate),
-	.request_address     (savestate_address),  
-	.request_busy        (savestate_busy)     
+	.request_address     (savestate_address),
+	.request_busy        (savestate_busy)
 );
 
 assign sleep_savestate = sleep_rewind | sleep_savestates;


### PR DESCRIPTION
This is several minor accuracy changes. Most of them are focused on edge case timings surrounding DMA and the APU line counter IRQ. There's also some bus fixes that properly isolates the behavior and selection of the APU registers and data bus that relate to the fact that on the real system the APU, DMA, and CPU were all internal to the same package.

I allowed 4 tests to keep failing:
- RNW2007 is behavior that is inconsistent between hardware revisions. It seems to mostly happen on later releases of the G revision PPUs.
- OAM corruption, arbitrary sprite 0, and OAM misalignment are all behavior surrounding the same hardware bug, and implementing that bug would require a significant refactor of the ppu code. It's best to not implement now but rather later perhaps with a full PPU refactor. The impact of this bug/feature is only cosmetic, so it should not make anyone feel insecure about core accuracy.