### PR TITLE
Fixes several issues, major rework of the PPU

### DIFF
--- a/NES.sv
+++ b/NES.sv
@@ -258,7 +258,7 @@ parameter CONF_STR = {
 	"P2O9,Swap Joysticks,No,Yes;",
 	"P2OA,Multitap,Disabled,Enabled;",
 	"P2oJK,SNAC,Off,Controllers,Zapper,3D Glasses;",
-	"P2o02,Periphery,None,Zapper(Mouse),Zapper(Joy1),Zapper(Joy2),Vaus,Vaus(A-Trigger),Powerpad,Family Trainer;",
+	"P2o02,Peripheral,None,Zapper(Mouse),Zapper(Joy1),Zapper(Joy2),Vaus,Vaus(A-Trigger),Powerpad,Family Trainer;",
 	"P2oL,Famicom Keyboard,No,Yes;",
 	"P2-;",
 	"P2OL,Zapper Trigger,Mouse,Joystick;",

--- a/NES.sv
+++ b/NES.sv
@@ -195,8 +195,8 @@ video_freak video_freak
 (
 	.*,
 	.VGA_DE_IN(vga_de),
-	.ARX((!ar) ? (hide_overscan ? 12'd64 : 12'd128) : (ar - 1'd1)),
-	.ARY((!ar) ? (hide_overscan ? 12'd49 : 12'd105) : 12'd0),
+	.ARX((!ar) ? (|hide_overscan ? (hide_overscan[1] ? 12'd4 : 12'd128) : 12'd64) : (ar - 1'd1)),
+	.ARY((!ar) ? (|hide_overscan ? (hide_overscan[1] ? 12'd3 : 12'd105) : 12'd49) : 12'd0),
 	.CROP_SIZE((en216p & vcrop_en) ? 10'd216 : 10'd0),
 	.CROP_OFF(voff),
 	.SCALE(status[40:39])
@@ -248,8 +248,7 @@ parameter CONF_STR = {
 	"d6P1O5,Vertical Crop,Disabled,216p(5x);",
 	"d6P1o36,Crop Offset,0,2,4,8,10,12,-12,-10,-8,-6,-4,-2;",
 	"P1o78,Scale,Normal,V-Integer,Narrower HV-Integer,Wider HV-Integer;",
-	"P1-;",
-	"P1O4,Hide Overscan,Off,On;",
+	"P1O[68:67],Overscan,Normal,Vertical Overscan,Borders,Everything;",
 	"P1ORS,Mask Edges,Off,Left,Both,Auto;",
 	"P1OP,Extra Sprites,Off,On;",
 	"P1-;",
@@ -271,8 +270,10 @@ parameter CONF_STR = {
 	"P3o9,Pause when OSD is open,Off,On;",
 	"P4,Advanced;",
 	"P4-;",
+	"P4O[66:65],RAM Clear,No,$00,$FF,Random;",
 	"P4O[64],PPU Reset Behavior,Famicom,NES;",
 	"P4OQ,Video Dijitter,Enabled,Disabled;",
+	"P4O[69],Debug Dots,Off,On;",
 	"- ;",
 	"R0,Reset;",
 	"J1,A,B,Select,Start,FDS,Mic,Zapper/Vaus Btn,PP/Mat 1,PP/Mat 2,PP/Mat 3,PP/Mat 4,PP/Mat 5,PP/Mat 6,PP/Mat 7,PP/Mat 8,PP/Mat 9,PP/Mat 10,PP/Mat 11,PP/Mat 12,Savestates;",
@@ -308,7 +309,7 @@ wire [127:0] status;
 
 wire arm_reset = status[0];
 wire pal_video = |status[24:23];
-wire hide_overscan = status[4] && ~pal_video;
+wire [1:0] hide_overscan = status[68:67];
 wire [3:0] palette2_osd = status[49:47];
 wire joy_swap = status[9] ^ (raw_serial || piano); // Controller on port 2 for Miracle Piano/SNAC
 wire fds_auto_eject = ~status[16];
@@ -320,8 +321,13 @@ wire int_audio = ~status[31];
 reg type_bios, type_fds, type_gg, type_nsf, type_nes, type_palette, is_bios, downloading;
 reg [24:0] rom_sz;
 
+wire [7:0] random_byte = q[7:0];
+wire feedback = q[31]^q[29]^q[28]^ q[27]^ q[23]^q[20]^ q[19]^q[17]^ q[15]^q[14]^q[12]^ q[11]^q[9]^ q[4]^ q[3]^q[2];
+reg [31:0] q = 32'haaaaaaaa;
+
 always_ff @(posedge clk) begin
 	reg old_downld;
+	q <= {q[30:0], feedback} ;
 
 	old_downld <= downloading;
 	loader_reset <= !download_reset || (~old_downld && downloading);
@@ -756,10 +762,14 @@ wire piano = (mapper_flags[30]);
 wire [3:0] prg_nvram = mapper_flags[34:31];
 wire loader_busy, loader_done, loader_fail;
 wire [9:0] prg_mask, chr_mask;
+wire [1:0] clearval = status[66:65];
+wire [7:0] cleardata = (clearval == 3) ? random_byte : (clearval == 2 ? 8'hFF : 8'h00);
 
 GameLoader loader
 (
 	.clk              ( clk               ),
+	.clearval         ( |clearval         ),
+	.cleardata        ( cleardata         ),
 	.reset            ( loader_reset      ),
 	.downloading      ( downloading       ),
 	.filetype         ( {4'b0000, type_nsf, type_fds, type_nes, type_bios} ),
@@ -842,6 +852,8 @@ always_ff @(posedge clk) begin
 	end
 end
 
+wire nes_hblank, nes_hsync, nes_vsync, nes_vblank;
+
 NES nes (
 	.clk             (clk),
 	.reset_nes       (reset_nes),
@@ -849,6 +861,7 @@ NES nes (
 	.cold_reset      (downloading & (type_fds | type_nes)),
 	.pausecore       (pausecore),
 	.corepaused      (corepaused),
+	.debug_dots	     (status[69]),
 	.sys_type        (status[24:23]),
 	.nes_div         (nes_ce),
 	.mapper_flags    (downloading ? 64'd0 : mapper_flags),
@@ -865,11 +878,15 @@ NES nes (
 	// Video
 	.ex_sprites      (status[25]),
 	.color           (color),
+	.hsync           (nes_hsync),
+	.hblank          (nes_hblank),
+	.vsync           (nes_vsync),
+	.vblank          (nes_vblank),
 	.emphasis        (emphasis),
 	.cycle           (cycle),
 	.scanline        (scanline),
-	.mask            (status[28:27]),
-	.dejitter_timing(status[26]),
+	.mask            (hide_overscan[1] ? 2'b00 : status[28:27]),
+	.dejitter_timing (status[26]),
 	// User Input
 	.joypad_out      (joypad_out),
 	.joypad_clock    (joypad_clock),
@@ -905,6 +922,8 @@ NES nes (
 	.bram_write      (bram_write),
 	.bram_override   (bram_en),
 	.save_written    (save_written),
+
+
 
 	// savestates
 	.mapper_has_savestate    (mapper_has_savestate),
@@ -1154,10 +1173,15 @@ video video
 	.clk(clk),
 	.reset(reset_nes),
 	.cnt(nes_ce_video),
+	.sys_type(status[24:23]),
+	.nes_hsync(nes_hsync),
+	.nes_hblank(nes_hblank),
+	.nes_vsync(nes_vsync),
+	.nes_vblank(nes_vblank),
 	.hold_reset(hold_reset),
 	.count_v(scanline),
 	.count_h(cycle),
-	.hide_overscan(hide_overscan),
+	.hide_overscan(pal_video && ~|hide_overscan ? 2'b01 : hide_overscan),
 	.palette(palette2_osd),
 	.load_color(pal_write && ioctl_download),
 	.load_color_data(pal_color),
@@ -1382,6 +1406,8 @@ module GameLoader
 	input         is_bios,
 	input   [7:0] indata,
 	input         indata_clk,
+	input         clearval,
+	input   [7:0] cleardata,
 	output reg [24:0] mem_addr,
 	output [7:0]  mem_data,
 	output        mem_write,
@@ -1408,7 +1434,7 @@ wire [7:0] chrrom = ines[5];	// Number of 8192 byte character ROM pages (0 indic
 wire [3:0] chrram = ines[11][3:0]; // NES 2.0 CHR-RAM size shift count (64 << count)
 wire has_chr_ram = ~is_nes20 ? (chrrom == 0) : |chrram;
 
-assign mem_data = (state == S_CLEARRAM || (~copybios && state == S_COPYBIOS)) ? 8'h00 : indata;
+assign mem_data = (state == S_CLEARRAM || (~copybios && state == S_COPYBIOS)) ? (clearval && ~(state == S_COPYBIOS) ? (mapper == 8'd232 ? 8'h00 : cleardata) : 8'h00) : indata;
 assign mem_write = (((bytes_left != 0) && (state == S_LOADPRG || state == S_LOADCHR || state == S_LOADEXTRA)
 	|| (downloading && (state == S_LOADHEADER || state == S_LOADFDS || state == S_LOADNSFH || state == S_LOADNSFD))) && indata_clk)
 	|| ((bytes_left != 0) && ((state == S_CLEARRAM) || (state == S_COPYBIOS) || (state == S_COPYPLAY)) && clearclk == 4'h2);
@@ -1580,6 +1606,12 @@ always @(posedge clk) begin
 			end else if (mapper == 8'd232) begin
 				mem_addr <= 25'b0_0011_1000_0000_0111_1111_1110; // Quattro - Clear these two RAM address to restart game menu
 				bytes_left <= 21'h2;
+				state <= S_CLEARRAM;
+				clearclk <= 4'h0;
+				cleardone <= 1;
+			end else if (clearval) begin
+				mem_addr <= 25'b0_0011_0000_0000_0000_0000_0000;
+				bytes_left <= 21'hF_FFFF;
 				state <= S_CLEARRAM;
 				clearclk <= 4'h0;
 				cleardone <= 1;

--- a/rtl/nes.v
+++ b/rtl/nes.v
@@ -293,7 +293,7 @@ always @(posedge clk) begin
 	end
 
 	// Add one extra PPU tick every 5 cpu cycles for PAL.
-	if (cpu_ce && sys_type[0])
+	if (cpu_ce && (sys_type == 2'b01))
 		cpu_tick_count <= cpu_tick_count[2] ? 3'd0 : cpu_tick_count + 1'b1;
 
 	// SDRAM Clock
@@ -494,7 +494,7 @@ APU apu(
 	.clk            (clk),
 	.PHI2           (phi2),
 	.CS             (apu_cs),
-	.PAL            (sys_type[0]),
+	.PAL            (sys_type == 2'b01),
 	.ce             (apu_ce),
 	.reset          (reset),
 	.cold_reset     (cold_reset),

--- a/rtl/nes.v
+++ b/rtl/nes.v
@@ -417,7 +417,8 @@ T65 cpu(
 	.mode   (0),
 	.BCD_en (0),
 
-	.res_n  (~cpu_reset),
+	.res_n  (~cpu_reset && ~cold_reset),
+	.pwr_n  (~cold_reset), // Cold boot, power reset, must be paired with reset
 	.clk    (clk),
 	.enable (cpu_ce),
 	.rdy    (~pause_cpu),

--- a/rtl/ppu.sv
+++ b/rtl/ppu.sv
@@ -1019,10 +1019,10 @@ initial begin
 end
 
 always @(posedge clk) if (pclk0) begin
-	if (enable) begin
-		if (latch_nametable)
-			current_name_table <= vram_data;
+	if (latch_nametable)
+		current_name_table <= vram_data;
 
+	if (enable) begin
 		if (latch_attrtable) begin
 			current_attribute_table <=
 				(!vram_v[1] && !vram_v[6]) ? vram_data[1:0] :
@@ -1415,7 +1415,7 @@ BgPainter bg_painter(
 	.clk            (clk),
 	.pclk0          (ce),
 	.clear          (reset),
-	.latch_nametable(cycle[2:0] == 2),
+	.latch_nametable(cycle[2:0] == 2 && re_sr[0]),
 	.latch_attrtable(cycle[2:0] == 4),
 	.latch_pattern1 (cycle[2:0] == 6),
 	.latch_pattern2 (cycle[2:0] == 0),
@@ -1615,13 +1615,13 @@ assign vram_a_ex = {1'b0, sprite_vram_addr_ex};
 
 wire special_dot = ~evenframe && cycle == 0 && scanline == 0; // This dot is skipped on even frames
 
-wire nametable_read = cycle[2:0] == 1 || cycle[2:0] == 2 || cycle > 336 || special_dot;
+wire nametable_read = cycle[2:0] == 1 || cycle[2:0] == 2 || (sprite_load_en && attribute_read) || cycle > 336 || special_dot;
 wire attribute_read = cycle[2:0] == 3 || cycle[2:0] == 4;
 wire pattern_table_upper = cycle[1:0] == 3 || cycle[1:0] == 0;
 wire read_cycle = ~cycle[0];
 
 always_comb begin
-	if (~is_rendering) begin
+	if (~is_rendering || (is_pre_render_line && cycle == 0)) begin
 		vram_a = vram[13:0];
 		vram_r_ex = 0;
 	end else begin

--- a/rtl/ppu.sv
+++ b/rtl/ppu.sv
@@ -344,27 +344,20 @@ reg [7:0] x_coord;     // X coordinate where we want things
 reg [7:0] pix1, pix2;  // Shift registers, output when x_coord == 0
 reg aprio;             // Current prio
 wire active = (x_coord == 0);
-reg sprite_active;
 
 always @(posedge clk) if (ce) begin
 	if (enable) begin
 		if (!active) begin
 			// Decrease until x_coord is zero.
 			x_coord <= x_coord - 8'h01;
-			if (x_coord == 2'd1 && rendering)
-				sprite_active <= 1;
 		end else if (rendering) begin
 			pix1 <= pix1 >> 1;
 			pix2 <= pix2 >> 1;
-		end else if (!sprite_active) begin
-			// If not rendering, and sprite misses its mark, it won't get rendered at all
-			pix1 <= '0;
-			pix2 <= '0;
 		end
 	end
 	if (load[3]) pix1 <= load_in[26:19];
 	if (load[2]) pix2 <= load_in[18:11];
-	if (load[1]) begin x_coord <= load_in[10:3]; sprite_active <= ~|load_in[10:3]; end
+	if (load[1]) x_coord <= load_in[10:3];
 	if (load[0]) {upper_color, aprio} <= load_in[2:0];
 end
 assign bits = {aprio, upper_color, active && pix2[0], active && pix1[0]};

--- a/rtl/ppu.sv
+++ b/rtl/ppu.sv
@@ -6,8 +6,8 @@
 
 import regs_savestates::*;
 
-// Module handles updating the loopy scroll register
-module LoopyGen (
+// Module handles updating the vram scroll register
+module VramAddressGen (
 	input clk,
 	input clear,
 	input ce,
@@ -18,9 +18,10 @@ module LoopyGen (
 	input read,          // read
 	input write,         // write
 	input is_pre_render, // Is this the pre-render scanline
+	input trigger_2007,
 	input [8:0] cycle,
-	output [14:0] loopy,
-	output [2:0] fine_x_scroll,  // Current loopy value
+	output [14:0] vram,
+	output [2:0] fine_x_scroll,  // Current vram value
 	// savestates
 	input [63:0]  SaveStateBus_Din,
 	input [ 9:0]  SaveStateBus_Adr,
@@ -29,148 +30,122 @@ module LoopyGen (
 	output [63:0] SaveStateBus_Dout
 );
 
-wire [63:0] SS_LOOPY;
-wire [63:0] SS_LOOPY_BACK;
-eReg_SavestateV #(SSREG_INDEX_LOOPY, SSREG_DEFAULT_LOOPY) iREG_SAVESTATE (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_Dout, SS_LOOPY_BACK, SS_LOOPY);
+wire [63:0] SS_vram;
+wire [63:0] SS_vram_BACK;
+eReg_SavestateV #(SSREG_INDEX_LOOPY, SSREG_DEFAULT_LOOPY) iREG_SAVESTATE (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_Dout, SS_vram_BACK, SS_vram);
 
 // Controls how much to increment on each write
 reg ppu_incr; // 0 = 1, 1 = 32
 // Current VRAM address
-reg [14:0] loopy_v;
+reg [14:0] vram_v;
 // Temporary VRAM address
-reg [14:0] loopy_t;
+reg [14:0] vram_t;
 // Fine X scroll (3 bits)
-reg [2:0] loopy_x;
+reg [2:0] vram_x;
 // Latch
 reg ppu_address_latch;
-reg [7:0] din_shift[2];
 reg [1:0] write_shift;
-reg [1:0] latch_shift;
 
-assign SS_LOOPY_BACK[    0] = ppu_incr;
-assign SS_LOOPY_BACK[15: 1] = loopy_v;
-assign SS_LOOPY_BACK[30:16] = loopy_t;
-assign SS_LOOPY_BACK[33:31] = loopy_x;
-assign SS_LOOPY_BACK[   34] = ppu_address_latch;
-assign SS_LOOPY_BACK[42:35] = din_shift[0];
-assign SS_LOOPY_BACK[50:43] = din_shift[1];
-assign SS_LOOPY_BACK[52:51] = write_shift;
-assign SS_LOOPY_BACK[54:53] = latch_shift;
-assign SS_LOOPY_BACK[63:55] = 9'b0; // free to be used
+assign SS_vram_BACK[    0] = ppu_incr;
+assign SS_vram_BACK[15: 1] = vram_v;
+assign SS_vram_BACK[30:16] = vram_t;
+assign SS_vram_BACK[33:31] = vram_x;
+assign SS_vram_BACK[   34] = ppu_address_latch;
+assign SS_vram_BACK[52:51] = write_shift;
+assign SS_vram_BACK[63:55] = 9'b0; // free to be used
 
-// Handle updating loopy_t and loopy_v
+wire inc_horizontal = (cycle[2:0] == 7 && ((cycle <= 255) || (cycle >= 320 && cycle <= 335)) && is_rendering);
+wire inc_vertical = (cycle == 255) && is_rendering;
+wire copy_hscroll = (cycle == 256) && is_rendering;
+wire copy_vscroll = (cycle >= 279 && cycle <= 303) && is_pre_render && is_rendering;
+
+wire write_2006b = write_shift[1];
+
+wire  [14:0] vram_t_mask;
+assign {vram_t_mask[10], vram_t_mask[4:0]} = (write_2006b || copy_hscroll) ? {vram_t[10], vram_t[4:0]} : 6'b11_1111;
+assign {vram_t_mask[14:11], vram_t_mask[9:5]} = (write_2006b || copy_vscroll) ? {vram_t[14:11], vram_t[9:5]} : 9'b1_1111_1111;
+
+// Handle updating vram_t and vram_v
 always @(posedge clk) begin
 	if (reset) begin
-		ppu_incr          <= SS_LOOPY[    0]; //0;
-		loopy_v           <= SS_LOOPY[15: 1]; //0;
-		loopy_t           <= SS_LOOPY[30:16]; //0;
-		loopy_x           <= SS_LOOPY[33:31]; //0;
-		ppu_address_latch <= SS_LOOPY[   34]; //0;
-		din_shift[0]      <= SS_LOOPY[42:35]; //0;
-		din_shift[1]      <= SS_LOOPY[50:43]; //0;
-		write_shift       <= SS_LOOPY[52:51]; //0;
-		latch_shift       <= SS_LOOPY[54:53]; //0;
+		ppu_incr          <= SS_vram[    0]; //0;
+		vram_v           <= SS_vram[15: 1]; //0;
+		vram_t           <= SS_vram[30:16]; //0;
+		vram_x           <= SS_vram[33:31]; //0;
+		ppu_address_latch <= SS_vram[   34]; //0;
+		write_shift       <= SS_vram[52:51]; //0;
 	end else if (ce) begin
-		if (is_rendering) begin
-			// Increment course X scroll right after attribute table byte was fetched.
-			if (cycle[2:0] == 3 && (cycle < 256 || cycle >= 320 && cycle < 336)) begin
-				loopy_v[4:0] <= loopy_v[4:0] + 1'd1;
-				loopy_v[10] <= loopy_v[10] ^ (loopy_v[4:0] == 31);
-			end
 
-			// Vertical Increment
-			if (cycle == 251) begin
-				loopy_v[14:12] <= loopy_v[14:12] + 1'd1;
-				if (loopy_v[14:12] == 7) begin
-					if (loopy_v[9:5] == 29) begin
-						loopy_v[9:5] <= 0;
-						loopy_v[11] <= !loopy_v[11];
-					end else begin
-						loopy_v[9:5] <= loopy_v[9:5] + 1'd1;
-					end
+		// Horizontal copy at cycle 256 and rendering OR if delayed 2006 write
+		if (copy_hscroll || write_2006b)
+			{vram_v[10], vram_v[4:0]} <= {vram_t[10], vram_t[4:0]};
+
+		// Vertical copy at Cycles 279 to 303 and rendering OR delayed 2006 write
+		if (copy_vscroll || write_2006b)
+			{vram_v[14:11], vram_v[9:5]} <= {vram_t[14:11], vram_t[9:5]};
+
+		// Increment course X scroll from (cycle 0-255 or 320-335) and cycle[2:0] == 7
+		if (inc_horizontal || (trigger_2007 && is_rendering)) begin
+			vram_v[4:0] <= (vram_v[4:0] + 1'd1) & vram_t_mask[4:0];
+			vram_v[10] <= (vram_v[10] ^ &vram_v[4:0]) & vram_t_mask[10];
+		end
+
+		// Vertical Increment at 255 and rendering
+		if (inc_vertical || (trigger_2007 && is_rendering)) begin
+			vram_v[14:12] <= (vram_v[14:12] + 1'd1) & vram_t_mask[14:12];
+			vram_v[9:5] <= vram_v[9:5] & vram_t_mask[9:5];
+			vram_v[11] <= vram_v[11] & vram_t_mask[11];
+			if (vram_v[14:12] == 7) begin
+				if (vram_v[9:5] == 29) begin
+					vram_v[9:5] <= 0;
+					vram_v[11] <= ~vram_v[11] & vram_t_mask[11];
+				end else begin
+					vram_v[9:5] <= (vram_v[9:5] + 1'd1) & vram_t_mask[9:5];
 				end
-			end
-
-			// Horizontal Reset at cycle 257
-			if (cycle == 256)
-				{loopy_v[10], loopy_v[4:0]} <= {loopy_t[10], loopy_t[4:0]};
-
-			// On cycle 256 of each scanline, copy horizontal bits from loopy_t into loopy_v
-			// On cycle 304 of the pre-render scanline, copy loopy_t into loopy_v
-			if (cycle == 304 && is_pre_render) begin
-				loopy_v <= loopy_t;
 			end
 		end
 
+		if (~is_rendering && trigger_2007 && !clear)
+			vram_v <= vram_v + (ppu_incr ? 15'd32 : 15'd1);
+
 		if (write && ain == 0) begin
-			loopy_t[10] <= din[0];
-			loopy_t[11] <= din[1];
+			vram_t[10] <= din[0];
+			vram_t[11] <= din[1];
 			ppu_incr <= din[2];
 		end else if (write && ain == 5) begin
 			if (!ppu_address_latch) begin
-				loopy_t[4:0] <= din[7:3];
-				loopy_x <= din[2:0];
+				vram_t[4:0] <= din[7:3];
+				vram_x <= din[2:0];
 			end else begin
-				loopy_t[9:5] <= din[7:3];
-				loopy_t[14:12] <= din[2:0];
+				vram_t[9:5] <= din[7:3];
+				vram_t[14:12] <= din[2:0];
 			end
 			ppu_address_latch <= !ppu_address_latch;
 		end else if (write && ain == 6) begin
 			ppu_address_latch <= !ppu_address_latch;
+			if (!ppu_address_latch) begin
+				vram_t[13:8] <= din[5:0];
+				vram_t[14] <= 0;
+			end else begin
+				vram_t[7:0] <= din;
+			end
 		end else if (read && ain == 2) begin
 			ppu_address_latch <= 0; //Reset PPU address latch
-		end else if ((read || write) && ain == 7) begin
-			// Increment address every time we accessed a reg
-			if (~is_rendering) begin
-				loopy_v <= loopy_v + (ppu_incr ? 15'd32 : 15'd1);
-			end else if (!clear) begin
-				// During rendering (on the pre-render line and the visible lines 0-239, provided either background or sprite rendering is
-				// enabled), it will update v in an odd way, triggering a coarse X increment and a Y increment simultaneously (with normal
-				// wrapping behavior). Internally, this is caused by the carry inputs to various sections of v being set up for rendering,
-				// and the $2007 access triggering a "load next value" signal for all of v (when not rendering, the carry inputs are set up
-				// to linearly increment v by either 1 or 32). This behavior is not affected by the status of the increment bit. The Young
-				// Indiana Jones Chronicles uses this for some effects to adjust the Y scroll during rendering, and also Burai Fighter (U)
-				// to draw the scorebar.
-				loopy_v[4:0] <= loopy_v[4:0] + 1'd1;
-				loopy_v[10] <= loopy_v[10] ^ (loopy_v[4:0] == 31);
-				loopy_v[14:12] <= loopy_v[14:12] + 1'd1;
-				if (loopy_v[14:12] == 7) begin
-					if (loopy_v[9:5] == 29) begin
-						loopy_v[9:5] <= 0;
-						loopy_v[11] <= !loopy_v[11];
-					end else begin
-						loopy_v[9:5] <= loopy_v[9:5] + 1'd1;
-					end
-				end
-			end
 		end
 
 		// Writes to vram address appear to be delayed by 2 cycles
-		latch_shift <= {latch_shift[0], ppu_address_latch};
-		write_shift <= {write_shift[0], (write && ain == 6)};
-		din_shift <= '{din, din_shift[0]};
-
-		if (write_shift[1]) begin
-			if (!latch_shift[1]) begin
-				loopy_t[13:8] <= din_shift[1][5:0];
-				loopy_t[14] <= 0;
-			end else begin
-				loopy_t[7:0] <= din_shift[1];
-				loopy_v <= {loopy_t[14:8], din_shift[1]};
-			end
-		end
+		write_shift <= {write_shift[0], (write && ain == 6) && ppu_address_latch};
 
 		if (clear) begin
-			loopy_t <= 0;
-			loopy_x <= 0;
+			vram_t <= 0;
+			vram_x <= 0;
 			ppu_address_latch <= 0;
 		end
-
 	end
 end
 
-assign loopy = loopy_v;
-assign fine_x_scroll = loopy_x;
+assign vram = vram_v;
+assign fine_x_scroll = vram_x;
 
 endmodule
 
@@ -193,6 +168,10 @@ module ClockGen #(parameter USE_SAVESTATE = 0) (
 	output short_frame,
 	output is_vbe_sl,
 	output evenframe,
+	output reg hsync,
+	output reg vsync,
+	output reg hblank,
+	output reg vblank,
 	// savestates
 	input [63:0]  SaveStateBus_Din,
 	input [ 9:0]  SaveStateBus_Adr,
@@ -238,8 +217,8 @@ assign at_last_cycle_group = (cycle[8:3] == 42);
 // For NTSC only, the *last* cycle of odd frames is skipped.
 // In Visual 2C02, the counter starts at zero and flips at scanline 256.
 assign short_frame = end_of_line & skip_pixel;
-
-wire skip_pixel = is_pre_render && ~even_frame_toggle && rendering_sr[3] && skip_en;
+reg skip_next = 0;
+wire skip_pixel = skip_next && skip_en;
 assign end_of_line = at_last_cycle_group && (cycle[3:0] == (skip_pixel ? 3 : 4));
 
 // Confimed with Visual 2C02
@@ -267,28 +246,63 @@ generate
 		assign SS_CLKGEN_BACK[22:14] = scanline;
 		assign SS_CLKGEN_BACK[   23] = is_pre_render;
 		assign SS_CLKGEN_BACK[   24] = even_frame_toggle;
-		assign SS_CLKGEN_BACK[63:25] = 39'b0; // free to be used
+		assign SS_CLKGEN_BACK[   25] = skip_next;
+		assign SS_CLKGEN_BACK[   26] = vblank;
+		assign SS_CLKGEN_BACK[   27] = hblank;
+		assign SS_CLKGEN_BACK[   28] = vsync;
+		assign SS_CLKGEN_BACK[   29] = hsync;
+		assign SS_CLKGEN_BACK[63:30] = 34'b0; // free to be used
 	end else begin
 		assign SS_CLKGEN         = 64'b0;
 		assign SaveStateBus_Dout = SS_CLKGEN;
 	end
 endgenerate
 
+wire hsync_period = (cycle >= 278 && cycle <= 302);
+wire hblank_period = (cycle >= 269 && cycle <= 326);
+
 // Set if the current line is line 0..239
 always @(posedge clk) if (reset) begin
+	skip_next <= 0;
 	if (USE_SAVESTATE) begin
 		cycle        <= SS_CLKGEN[  8:0]; // 338;
 		is_in_vblank <= SS_CLKGEN[    9]; // 0;
 		rendering_sr <= SS_CLKGEN[13:10]; // no reset before => 0 should be ok;
+		skip_next    <= SS_CLKGEN[   25]; // 0;
+		vblank       <= SS_CLKGEN[   26]; // 0;
+		hblank       <= SS_CLKGEN[   27]; // 0;
+		vsync        <= SS_CLKGEN[   28]; // 0;
+		hsync        <= SS_CLKGEN[   29]; // 0;
 	end else begin
 		cycle        <= 338;
 		is_in_vblank <= 0;
+		rendering_sr <= '0;
+		skip_next    <= 0;
+		vblank       <= 0;
+		hblank       <= 0;
+		vsync        <= 0;
+		hsync        <= 0;
 	end
 end else if (ce) begin
-	// On a real AV famicom, the NMI even_odd_timing test fails with 09, this SR is to make that happen
+	if (cycle == 338) begin
+		skip_next <= is_pre_render && ~even_frame_toggle && is_rendering && skip_en;
+	end
 	rendering_sr <= {rendering_sr[2:0], is_rendering};
 	cycle <= end_of_line ? 9'd0 : cycle + 9'd1;
 	is_in_vblank <= new_is_in_vblank;
+
+	hsync <= hsync_period;
+	hblank <= hblank_period;
+
+	if (scanline == (vblank_start_sl + 3'd3) && hsync_period)
+		vsync <= 1;
+	if (scanline == (vblank_start_sl + 3'd6) && hsync_period)
+		vsync <= 0;
+
+	if (scanline == vblank_start_sl && hblank_period)
+		vblank <= 1;
+	if (is_pre_render && hblank_period)
+		vblank <= 0;
 end
 
 always @(posedge clk) if (reset) begin
@@ -318,6 +332,7 @@ module Sprite(
 	input clk,
 	input ce,
 	input enable,
+	input rendering,
 	input [3:0] load,
 	input [26:0] load_in,
 	output [26:0] load_out,
@@ -329,20 +344,27 @@ reg [7:0] x_coord;     // X coordinate where we want things
 reg [7:0] pix1, pix2;  // Shift registers, output when x_coord == 0
 reg aprio;             // Current prio
 wire active = (x_coord == 0);
+reg sprite_active;
 
 always @(posedge clk) if (ce) begin
 	if (enable) begin
 		if (!active) begin
 			// Decrease until x_coord is zero.
 			x_coord <= x_coord - 8'h01;
-		end else begin
+			if (x_coord == 2'd1 && rendering)
+				sprite_active <= 1;
+		end else if (rendering) begin
 			pix1 <= pix1 >> 1;
 			pix2 <= pix2 >> 1;
+		end else if (!sprite_active) begin
+			// If not rendering, and sprite misses its mark, it won't get rendered at all
+			pix1 <= '0;
+			pix2 <= '0;
 		end
 	end
 	if (load[3]) pix1 <= load_in[26:19];
 	if (load[2]) pix2 <= load_in[18:11];
-	if (load[1]) x_coord <= load_in[10:3];
+	if (load[1]) begin x_coord <= load_in[10:3]; sprite_active <= ~|load_in[10:3]; end
 	if (load[0]) {upper_color, aprio} <= load_in[2:0];
 end
 assign bits = {aprio, upper_color, active && pix2[0], active && pix1[0]};
@@ -357,6 +379,7 @@ module SpriteSet(
 	input clk,
 	input ce,               // Input clock
 	input enable,           // Enable pixel generation
+	input rendering,        // Set to 1 if rendering is enabled
 	input [3:0] load,       // Which parts of the state to load/shift.
 	input [3:0] load_ex,    // Which parts of the state to load/shift for extra sprites.
 	input [26:0] load_in,   // State to load with
@@ -372,24 +395,24 @@ wire [4:0] bits7, bits6, bits5, bits4, bits3, bits2, bits1, bits0,
 	bits15, bits14, bits13, bits12, bits11, bits10, bits9, bits8;
 
 // Extra sprites
-Sprite sprite15(clk, ce, enable, load_ex, load_in_ex, load_out15, bits15);
-Sprite sprite14(clk, ce, enable, load_ex, load_out15, load_out14, bits14);
-Sprite sprite13(clk, ce, enable, load_ex, load_out14, load_out13, bits13);
-Sprite sprite12(clk, ce, enable, load_ex, load_out13, load_out12, bits12);
-Sprite sprite11(clk, ce, enable, load_ex, load_out12, load_out11, bits11);
-Sprite sprite10(clk, ce, enable, load_ex, load_out11, load_out10, bits10);
-Sprite sprite9( clk, ce, enable, load_ex, load_out10, load_out9,  bits9);
-Sprite sprite8( clk, ce, enable, load_ex, load_out9,  load_out8,  bits8);
+Sprite sprite15(clk, ce, enable, rendering, load_ex, load_in_ex, load_out15, bits15);
+Sprite sprite14(clk, ce, enable, rendering, load_ex, load_out15, load_out14, bits14);
+Sprite sprite13(clk, ce, enable, rendering, load_ex, load_out14, load_out13, bits13);
+Sprite sprite12(clk, ce, enable, rendering, load_ex, load_out13, load_out12, bits12);
+Sprite sprite11(clk, ce, enable, rendering, load_ex, load_out12, load_out11, bits11);
+Sprite sprite10(clk, ce, enable, rendering, load_ex, load_out11, load_out10, bits10);
+Sprite sprite9( clk, ce, enable, rendering, load_ex, load_out10, load_out9,  bits9);
+Sprite sprite8( clk, ce, enable, rendering, load_ex, load_out9,  load_out8,  bits8);
 
 // Basic Sprites
-Sprite sprite7( clk, ce, enable, load, load_in,    load_out7,  bits7);
-Sprite sprite6( clk, ce, enable, load, load_out7,  load_out6,  bits6);
-Sprite sprite5( clk, ce, enable, load, load_out6,  load_out5,  bits5);
-Sprite sprite4( clk, ce, enable, load, load_out5,  load_out4,  bits4);
-Sprite sprite3( clk, ce, enable, load, load_out4,  load_out3,  bits3);
-Sprite sprite2( clk, ce, enable, load, load_out3,  load_out2,  bits2);
-Sprite sprite1( clk, ce, enable, load, load_out2,  load_out1,  bits1);
-Sprite sprite0( clk, ce, enable, load, load_out1,  load_out0,  bits0);
+Sprite sprite7( clk, ce, enable, rendering, load, load_in,    load_out7,  bits7);
+Sprite sprite6( clk, ce, enable, rendering, load, load_out7,  load_out6,  bits6);
+Sprite sprite5( clk, ce, enable, rendering, load, load_out6,  load_out5,  bits5);
+Sprite sprite4( clk, ce, enable, rendering, load, load_out5,  load_out4,  bits4);
+Sprite sprite3( clk, ce, enable, rendering, load, load_out4,  load_out3,  bits3);
+Sprite sprite2( clk, ce, enable, rendering, load, load_out3,  load_out2,  bits2);
+Sprite sprite1( clk, ce, enable, rendering, load, load_out2,  load_out1,  bits1);
+Sprite sprite0( clk, ce, enable, rendering, load, load_out1,  load_out0,  bits0);
 
 // Determine which sprite is visible on this pixel.
 assign bits = bits_orig;
@@ -422,6 +445,8 @@ module OAMEval(
 	input clk,
 	input ce,
 	input reset,
+	input clear_signal,
+	input end_of_line,
 	input rendering_enabled,   // Set to 1 if evaluations are enabled
 	input obj_size,            // Set to 1 if objects are 16 pixels.
 	input [8:0] scanline,      // Current scan line (compared against Y)
@@ -431,10 +456,11 @@ module OAMEval(
 	input oam_addr_write,      // Load oam with specified value, when writing to NES $2003.
 	input oam_data_write,      // Load oam_ptr with specified value, when writing to NES $2004.
 	input [7:0] oam_din,       // New value for oam or oam_ptr
-	output reg spr_overflow,   // Set to true if we had more than 8 objects on a scan line. Reset when exiting vblank.
+	output reg overflow,   // Set to true if we had more than 8 objects on a scan line. Reset when exiting vblank.
 	output reg sprite0,        // True if sprite#0 is included on the scan line currently being painted.
 	input is_vbe,              // Last line before pre-render
 	input PAL,
+	output in_range,
 	output masked_sprites,     // If the game is trying to mask extra sprites
 	// savestates
 	input [63:0]  SaveStateBus_Din,
@@ -460,6 +486,7 @@ eReg_SavestateV #(SSREG_INDEX_OAMEVAL, SSREG_DEFAULT_OAMEVAL) iREG_SAVESTATE (cl
 // https://forums.nesdev.com/viewtopic.php?f=3&t=19005
 
 assign oam_bus = oam_data;
+wire [7:0] oam_dbus = oam_data_write ? oam_din : oam_data;
 
 enum {
 	STATE_IDLE,
@@ -472,23 +499,43 @@ enum {
 reg [7:0] oam_temp[64];    // OAM Temporary buffer, normally 32 bytes, 64 for extra sprites
 reg [7:0] oam[256];        // OAM RAM, 256 bytes
 reg [7:0] oam_addr;        // OAM Address Register 2003
-reg [2:0] oam_temp_slot;   // Pointer to oam_temp;
+reg [2:0] oam_secondary_row;   // Pointer to oam_temp;
 reg [7:0] oam_data;        // OAM Data Register 2004
-reg oam_temp_wren;         // Write enable for OAM temp, disabled if full
+reg oam_secondary_ovr;         // Write enable for OAM temp, disabled if full
 
 // Extra Registers
 reg [5:0] oam_addr_ex;     // OAM pointer for use with extra sprites
-reg [3:0] oam_temp_slot_ex;
-reg [1:0] m_ex;				// unused?
-reg [7:0] oam_data_ex;     // unused?
+reg [3:0] oam_secondary_row_ex;
 reg [2:0] spr_counter;     // Count sprites
+
+reg old_rendering;
+reg old_using_secondary;
 
 wire visible = (scanline < 240);
 wire rendering = (scanline == 9'd511 || visible) && rendering_enabled;
 wire evaluating = visible && rendering_enabled;
+wire secondary_write = cycle[0];
 
-reg [5:0] oam_temp_addr;
-reg [6:0] feed_cnt;
+wire [7:0] oam_read_addr = oam_addr_write ? oam_din : oam_addr;
+wire is_attr_byte = oam_read_addr[1:0] == 2'b10;
+
+// Note the following corruption evaluation is NOT suitable for use generally because of it's combinational nature
+wire using_secondary = rendering && ((~cycle[0] && cycle <= 8'd255) || cycle > 8'd255) ? 1'b1 : 1'b0;
+wire [4:0] oam_row_cur = using_secondary ? oam_secondary_addr : (oam_addr_write ? oam_din[7:3] : oam_addr[7:3]);
+wire [4:0] oam_row_last = old_using_secondary ? oam_secondary_addr : oam_addr[7:3];
+
+// 2003 writes will cause a ram row corruption ONLY when the write occurs during the wrong *half*
+// of a PPU cycle. During certain cpu/ppu alignments, including the "good" alignment, this won't
+// occur at all. It seems to cause problems sometimes so I'll leave it here as reference but
+// it seems best to keep it disabled until actual unaligned PPU can be implemented.
+
+wire corrupting_write = 0;// (oam_addr_write & ~using_secondary);
+
+assign in_range = scanline[7:0] >= oam_dbus && scanline[7:0] < oam_dbus + (obj_size ? 16 : 8);
+
+wire clear_secondary_addr = ((cycle == 63) || (cycle == 255) || (cycle == 339)) && rendering;
+
+reg [4:0] oam_secondary_addr;
 
 reg sprite0_curr;
 reg [2:0] repeat_count;
@@ -496,40 +543,38 @@ reg [2:0] repeat_count;
 assign masked_sprites = &repeat_count;
 
 reg n_ovr, ex_ovr;
-reg [1:0] eval_counter;
-reg overflow;
+reg [1:0] oam_secondary_column;
 
 assign SS_OAMEVAL_BACK[ 7: 0] = oam_data;
-assign SS_OAMEVAL_BACK[    8] = oam_temp_wren;
-assign SS_OAMEVAL_BACK[14: 9] = oam_temp_addr;
-assign SS_OAMEVAL_BACK[17:15] = oam_temp_slot;
-assign SS_OAMEVAL_BACK[21:18] = oam_temp_slot_ex;
+assign SS_OAMEVAL_BACK[    8] = ~oam_secondary_ovr;
+assign SS_OAMEVAL_BACK[14: 9] = oam_secondary_addr;
+assign SS_OAMEVAL_BACK[17:15] = oam_secondary_row;
+assign SS_OAMEVAL_BACK[21:18] = oam_secondary_row_ex;
 assign SS_OAMEVAL_BACK[   22] = n_ovr;
 assign SS_OAMEVAL_BACK[25:23] = spr_counter;
 assign SS_OAMEVAL_BACK[28:26] = repeat_count;
 assign SS_OAMEVAL_BACK[   29] = sprite0;
 assign SS_OAMEVAL_BACK[   30] = sprite0_curr;
-assign SS_OAMEVAL_BACK[37:31] = feed_cnt;
 assign SS_OAMEVAL_BACK[   38] = overflow;
-assign SS_OAMEVAL_BACK[40:39] = eval_counter;
+assign SS_OAMEVAL_BACK[40:39] = oam_secondary_column;
 assign SS_OAMEVAL_BACK[   41] = ex_ovr;
 assign SS_OAMEVAL_BACK[47:42] = oam_addr_ex;
 assign SS_OAMEVAL_BACK[55:48] = oam_addr;
 assign SS_OAMEVAL_BACK[58:56] = (oam_state == STATE_IDLE)  ? 3'd0 :
-										  (oam_state == STATE_CLEAR) ? 3'd1 :
-										  (oam_state == STATE_EVAL)  ? 3'd2 :
-										  (oam_state == STATE_FETCH) ? 3'd3 :
-																				 3'd4;
-assign SS_OAMEVAL_BACK[63:59] = 5'b0; // free to be used
+	(oam_state == STATE_CLEAR) ? 3'd1 :
+	(oam_state == STATE_EVAL)  ? 3'd2 :
+	(oam_state == STATE_FETCH) ? 3'd3 :
+	3'd4;
+assign SS_OAMEVAL_BACK[59] = old_rendering;
+assign SS_OAMEVAL_BACK[60] = old_using_secondary;
+assign SS_OAMEVAL_BACK[37:31] = '0; // free to be used
+assign SS_OAMEVAL_BACK[63:61] = 3'b0; // free to be used
 
 always @(posedge clk) begin :oam_eval
-reg old_rendering; // unused?
-reg [8:0] last_y, last_tile, last_attr; // unused?
 
-if (cycle == 340 && ce) begin
-	sprite0 <= sprite0_curr;
-	sprite0_curr <= 0;
-end
+reg [8:0] last_y, last_tile, last_attr; // unused?
+reg [1:0] eval_count;
+reg sec_ovr;
 
 if (Savestate_OAMRdEn) Savestate_OAMReadData  <= oam[Savestate_OAMAddr];
 if (Savestate_OAMWrEn) oam[Savestate_OAMAddr] <= Savestate_OAMWriteData;
@@ -538,18 +583,17 @@ if (reset) begin
 	oam_temp <= '{64{8'hFF}};
 
 	oam_data         <= SS_OAMEVAL[ 7: 0]; //oam_temp[0] == 8'hFF
-	oam_temp_wren    <= SS_OAMEVAL[    8]; //1;
-	oam_temp_addr    <= SS_OAMEVAL[14: 9]; //0;
-	oam_temp_slot    <= SS_OAMEVAL[17:15]; //0;
-	oam_temp_slot_ex <= SS_OAMEVAL[21:18]; //0;
+	oam_secondary_ovr    <= ~SS_OAMEVAL[    8]; //1;
+	oam_secondary_addr    <= SS_OAMEVAL[13: 9]; //0;
+	oam_secondary_row    <= SS_OAMEVAL[17:15]; //0;
+	oam_secondary_row_ex <= SS_OAMEVAL[21:18]; //0;
 	n_ovr            <= SS_OAMEVAL[   22]; //0;
 	spr_counter      <= SS_OAMEVAL[25:23]; //0;
 	repeat_count     <= SS_OAMEVAL[28:26]; //0;
 	sprite0          <= SS_OAMEVAL[   29]; //0;
 	sprite0_curr     <= SS_OAMEVAL[   30]; //0;
-	feed_cnt         <= SS_OAMEVAL[37:31]; //0;
 	overflow         <= SS_OAMEVAL[   38]; //0;
-	eval_counter     <= SS_OAMEVAL[40:39]; //0;
+	oam_secondary_column     <= SS_OAMEVAL[40:39]; //0;
 	ex_ovr           <= SS_OAMEVAL[   41]; //0;
 	oam_addr_ex      <= SS_OAMEVAL[47:42]; //0;
 	oam_addr         <= SS_OAMEVAL[55:48]; //0;
@@ -560,57 +604,60 @@ if (reset) begin
 		3: oam_state <= STATE_FETCH;
 		4: oam_state <= STATE_REFRESH;
 	endcase
+	old_rendering <= SS_OAMEVAL[59];
+	old_using_secondary <= SS_OAMEVAL[60];
 end else if (ce) begin
 
 	// State machine. Remember these will be one ppu cycle early.
 	case (cycle)
-		337: oam_state <= STATE_IDLE;    // 1 cycle
-		338,0: oam_state <= STATE_CLEAR; // 64 cycles
-		62:  oam_state <= STATE_EVAL;    // 192 cycles
-		254: oam_state <= STATE_FETCH;   // 64 cycles
-		318: oam_state <= STATE_REFRESH; // 19 cycles
+		340: oam_state <= STATE_CLEAR;   // 64 cycles
+		63:  oam_state <= STATE_EVAL;    // 192 cycles
+		255: oam_state <= STATE_FETCH;   // 64 cycles
+		319: oam_state <= STATE_REFRESH; // 19 cycles
 	endcase
+	if (end_of_line)
+		oam_state <= STATE_CLEAR;
 
-	// It is also the case that if OAMADDR is not less than eight when rendering starts,
-	// the eight bytes starting at OAMADDR & 0xF8 are copied to the first eight bytes
-	// of OAM
-	if (rendering && cycle == 0) begin
-		if (|oam_addr[7:3] && ~PAL) begin
-			oam[0] <= oam[{oam_addr[7:3], 3'b000}];
-			oam[1] <= oam[{oam_addr[7:3], 3'b001}];
-			oam[2] <= oam[{oam_addr[7:3], 3'b010}];
-			oam[3] <= oam[{oam_addr[7:3], 3'b011}];
-			oam[4] <= oam[{oam_addr[7:3], 3'b100}];
-			oam[5] <= oam[{oam_addr[7:3], 3'b101}];
-			oam[6] <= oam[{oam_addr[7:3], 3'b110}];
-			oam[7] <= oam[{oam_addr[7:3], 3'b111}];
+	old_rendering <= rendering;
+	old_using_secondary <= using_secondary;
+
+	if (((old_rendering != rendering) || corrupting_write) && ~PAL) begin
+		if ((old_using_secondary != using_secondary) || corrupting_write) begin
+			oam[{oam_row_cur, 3'b000}] <= oam[{oam_row_last, 3'b000}];
+			oam[{oam_row_cur, 3'b001}] <= oam[{oam_row_last, 3'b001}];
+			oam[{oam_row_cur, 3'b010}] <= oam[{oam_row_last, 3'b010}];
+			oam[{oam_row_cur, 3'b011}] <= oam[{oam_row_last, 3'b011}];
+			oam[{oam_row_cur, 3'b100}] <= oam[{oam_row_last, 3'b100}];
+			oam[{oam_row_cur, 3'b101}] <= oam[{oam_row_last, 3'b101}];
+			oam[{oam_row_cur, 3'b110}] <= oam[{oam_row_last, 3'b110}];
+			oam[{oam_row_cur, 3'b111}] <= oam[{oam_row_last, 3'b111}];
+			oam_temp[oam_row_cur] <= oam_temp[oam_row_last];
 		end
 	end
 
 	// XXX this is outside the "evaluating" block because of timing issues
-	if (rendering) begin
-		if (oam_state == STATE_IDLE) begin
-			oam_data <= oam_temp[0];
-			oam_temp_addr <= 0;
-			oam_temp_slot <= 0;
-			oam_temp_wren <= 1;
-			oam_temp_slot_ex <= 0;
-			oam_addr_ex <= 0;
-			n_ovr <= 0;
-			ex_ovr <= 0;
-			spr_counter <= 0;
-			repeat_count <= 0;
-			feed_cnt <= 0;
-			eval_counter <= 0;
-			oam_bus_ex <= 32'hFFFFFFFF;
-		end else if (oam_state == STATE_CLEAR) begin               // Initialization state
-			oam_data <= 8'hFF;
+	if (end_of_line) begin
+		oam_secondary_row_ex <= 0;
+		oam_addr_ex <= 0;
+		ex_ovr <= 0;
+		spr_counter <= 0;
+		repeat_count <= 0;
+		oam_bus_ex <= 32'hFFFFFFFF;
+	end
 
-			if (~cycle[0]) begin
-				oam_temp[oam_temp_addr] <= 8'hFF;
+	if (rendering) begin
+		if (oam_state == STATE_CLEAR) begin               // Initialization state
+			oam_data <= 8'hFF;
+			n_ovr <= 0;
+
+			if (secondary_write) begin
+				if (~oam_secondary_ovr) begin // If this overflows due to rendering status corrupting the addr, oamdata will still be FF
+					oam_temp[oam_secondary_addr] <= 8'hFF;
+					{oam_secondary_ovr, oam_secondary_addr} <= {1'b0, oam_secondary_addr} + 6'd1;
+				end
+
 				// Clear extra sprite space too
-				oam_temp[oam_temp_addr + 6'd32] <= 8'hFF;
-				oam_temp_addr <= oam_temp_addr + 1'b1;
+				oam_temp[{1'b1, oam_secondary_addr}] <= 8'hFF;
 			end
 
 			// During init, we hunt for the 8th sprite in OAM, so we know where to start for extra sprites
@@ -627,122 +674,126 @@ end else if (ce) begin
 					{ex_ovr, oam_addr_ex} <= oam_addr_ex + 7'd1;
 					if (scanline[7:0] >= oam[{oam_addr_ex, 2'b00}] &&
 						scanline[7:0] < oam[{oam_addr_ex, 2'b00}] + (obj_size ? 16 : 8)) begin
-						if (oam_temp_slot_ex < 8) begin // Turbo style.
-							oam_temp_slot_ex <= oam_temp_slot_ex + 1'b1;
-							oam_temp[{oam_temp_slot_ex, 2'b00} + 6'd32] <= oam[{oam_addr_ex, 2'b00}];
-							oam_temp[{oam_temp_slot_ex, 2'b01} + 6'd32] <= oam[{oam_addr_ex, 2'b01}];
-							oam_temp[{oam_temp_slot_ex, 2'b10} + 6'd32] <= oam[{oam_addr_ex, 2'b10}];
-							oam_temp[{oam_temp_slot_ex, 2'b11} + 6'd32] <= oam[{oam_addr_ex, 2'b11}];
+						if (oam_secondary_row_ex < 8) begin // Turbo style.
+							oam_secondary_row_ex <= oam_secondary_row_ex + 1'b1;
+							oam_temp[{oam_secondary_row_ex, 2'b00} + 6'd32] <= oam[{oam_addr_ex, 2'b00}];
+							oam_temp[{oam_secondary_row_ex, 2'b01} + 6'd32] <= oam[{oam_addr_ex, 2'b01}];
+							oam_temp[{oam_secondary_row_ex, 2'b10} + 6'd32] <= oam[{oam_addr_ex, 2'b10}];
+							oam_temp[{oam_secondary_row_ex, 2'b11} + 6'd32] <= oam[{oam_addr_ex, 2'b11}];
 						end
 					end
 				end
 
-				//On odd cycles, data is read from (primary) OAM
-				if (cycle[0]) begin
-					oam_data <= oam[oam_addr];
+				//On even cycles, data is read from (primary) OAM
+				if (!secondary_write) begin
+					oam_data <= (oam[oam_read_addr] & (is_attr_byte ? 8'hE3 : 8'hFF));
 				end else begin
-					if (~n_ovr) begin
-						if (oam_temp_wren)
-							oam_temp[{1'b0, oam_temp_slot, oam_addr[1:0]}] <= oam_data;
-						else
-							oam_data <= oam_temp[{1'b0, oam_temp_slot, 2'b00}];
-						if (~|eval_counter) begin // m is 0
-							if (scanline[7:0] >= oam_data && scanline[7:0] < oam_data + (obj_size ? 16 : 8)) begin
-								if (~oam_temp_wren)
-									overflow <= 1;
-								if (~|oam_addr[7:2])
-									sprite0_curr <= 1'b1;
-								eval_counter <= eval_counter + 2'd1;
-								{n_ovr, oam_addr} <= {1'b0, oam_addr} + 9'd1; // is good, copy
-							end else begin
-								if (~oam_temp_wren) begin  // Sprite overflow bug emulation
-									{n_ovr, oam_addr[7:2]} <= oam_addr[7:2] + 7'd1;
-									oam_addr[1:0] <= oam_addr[1:0] + 2'd1;
-								end else begin                              // skip to next sprite
-									{n_ovr, oam_addr} <= oam_addr + 9'd4;
-								end
-							end
-						end else begin
-							eval_counter <= eval_counter + 2'd1;
+					if (~oam_secondary_ovr && ~n_ovr) // The Attr byte of secondary OAM is NOT missing bits 4:2
+						oam_temp[oam_secondary_addr] <= oam_dbus;
+					else
+						oam_data <= oam_temp[oam_secondary_addr];
+
+					if (cycle == 65)
+						sprite0_curr <= in_range;
+
+					if (eval_count == 2'd0) begin // Evaluate Y for in_range
+						if (in_range && ~n_ovr) begin
+							eval_count <= 2'd1; // is good, start copy
 							{n_ovr, oam_addr} <= {1'b0, oam_addr} + 9'd1;
 
-							if (&eval_counter) begin // end of copy
-								if (oam_temp_wren) begin
-									last_y <= oam[{oam_addr[7:2], 2'b00}];
-									last_tile <= oam[{oam_addr[7:2], 2'b01}];
-									last_attr <= oam[{oam_addr[7:2], 2'b10}];
-									// Check for repeats to see if the game is trying to mask sprites
-									if (|oam_temp_slot &&
-										last_y == oam[{oam_addr[7:2], 2'b00}] &&
-										last_tile == oam[{oam_addr[7:2], 2'b01}] &&
-										last_attr == oam[{oam_addr[7:2], 2'b10}]) begin
-										repeat_count <= repeat_count + 3'd1;
-									end
-									oam_temp_slot <= oam_temp_slot+ 1'b1;
-								end else begin
-									n_ovr <= 1;
-								end
+							if (~oam_secondary_ovr) begin
+								{oam_secondary_ovr, oam_secondary_addr} <= {1'b0, oam_secondary_addr} + 6'd1;
+							end else begin
+								overflow <= 1; // Overflow is set when Y is in range, oam_secondary_ovr is set, n_ovr is not set
+							end
 
-								if (oam_temp_slot == 7)
-									oam_temp_wren <= 0;
+						end else begin
+							if (oam_secondary_ovr & ~n_ovr) begin // Not in range but due to the secondary oam read, it buggily triggers a +1 increment too
+								{n_ovr, oam_addr[7:2]} <= {1'b0, oam_addr[7:2]} + 6'd1;
+								oam_addr[1:0] <= oam_addr[1:0] + 2'd1;
+							end else begin // Normal and proper advance to the next Y position "slot"
+								{n_ovr, oam_addr} <= ({1'b0, oam_addr} + 9'd4) & 9'h1FC;
 							end
 						end
+					end else if (eval_count == 2'd3) begin // end of copy
+						// Due to a hardware bug, X is evaluated with the same logic as Y,
+						// under normal circumstances regardless of if true or false, the outcome is the same
+						// but if the oamaddress is misaligned, the oamaddress increments differently in practice.
+						if (in_range && ~n_ovr) begin
+							{n_ovr, oam_addr} <= {1'b0, oam_addr} + 9'd1;
+						end else begin
+							if (oam_secondary_ovr & ~n_ovr) begin // Same buggy increment as y if secondary oam is full
+								{n_ovr, oam_addr} <= {1'b0, oam_addr} + 9'd5;
+							end else begin
+								{n_ovr, oam_addr} <= ({1'b0, oam_addr} + 9'd1) & 9'h1FC;
+							end
+						end
+
+						// Some kludgy stuff for extra sprite evaluation
+						if (~oam_secondary_ovr) begin
+							last_y <= oam[{oam_addr[7:2], 2'b00}];
+							last_tile <= oam[{oam_addr[7:2], 2'b01}];
+							last_attr <= oam[{oam_addr[7:2], 2'b10}];
+							// Check for repeats to see if the game is trying to mask sprites
+							if (|oam_secondary_addr[4:2] &&
+								last_y == oam[{oam_addr[7:2], 2'b00}] &&
+								last_tile == oam[{oam_addr[7:2], 2'b01}] &&
+								last_attr == oam[{oam_addr[7:2], 2'b10}]) begin
+								repeat_count <= repeat_count + 3'd1;
+							end
+						end else begin
+							// The reason this flag is set is because to get here, overflow must have been set and it sets this flag
+							n_ovr <= 1;
+						end
 					end else begin
-						oam_addr <= {oam_addr[7:2] + 1'd1, 2'b00};
-						oam_data <= oam_temp[{1'b0, oam_temp_slot, 2'b00}];
+						{n_ovr, oam_addr} <= {1'b0, oam_addr} + 9'd1;
 					end
 				end
 				// Check if the 9th sprite is a repeat
 				if (last_y    == oam_temp[6'd32] &&
 					last_tile == oam_temp[6'd33] &&
 					last_attr == oam_temp[6'd34] &&
-					cycle == 9'h0FD && repeat_count < 7)
+					cycle == 9'd255 && repeat_count < 7)
 					repeat_count <= repeat_count + 3'd1;
 			end
+
+			if (n_ovr) n_ovr <= 1;// Prevent this from being cleared by oam primary rollover
+
 		end else if (oam_state == STATE_FETCH) begin
-			feed_cnt <= feed_cnt + 1'd1;
+			oam_addr <= '0;
+			sprite0 <= sprite0_curr;
+			oam_data <= oam_temp[oam_secondary_addr];
 
-			case (feed_cnt[2:0])
-				0: begin // Y Coord
-					oam_data <= oam_temp[{feed_cnt[6:3], 2'b00}];
-					oam_bus_ex <= {
-						oam_temp[{(feed_cnt[6:3] + 4'd8), 2'b11}],
-						oam_temp[{(feed_cnt[6:3] + 4'd8), 2'b10}],
-						oam_temp[{(feed_cnt[6:3] + 4'd8), 2'b01}],
-						oam_temp[{(feed_cnt[6:3] + 4'd8), 2'b00}]
-					};
-				end
+			if ((cycle[2:0] < 4'd3 || cycle[2:0] == 3'd7) && ~oam_secondary_ovr)
+				{oam_secondary_ovr, oam_secondary_addr} <= {1'b0, oam_secondary_addr} + 6'd1;
 
-				1: begin // Tile Num
-					oam_data <= oam_temp[{feed_cnt[6:3], 2'b01}];
-				end
-
-				2: begin // Attr
-					oam_data <= oam_temp[{feed_cnt[6:3], 2'b10}];
-				end
-
-				3,4,5,6,7: begin // X Coord
-					oam_data <= oam_temp[{feed_cnt[6:3], 2'b11}];
-				end
-			endcase
+			if (cycle[2:0] == 3'd0) begin
+				oam_bus_ex <= {
+					oam_temp[{1'b1, oam_secondary_addr[4:2], 2'b11}],
+					oam_temp[{1'b1, oam_secondary_addr[4:2], 2'b10}],
+					oam_temp[{1'b1, oam_secondary_addr[4:2], 2'b01}],
+					oam_temp[{1'b1, oam_secondary_addr[4:2], 2'b00}]
+				};
+			end
 		end else begin // STATE_REFRESH
 			oam_data <= oam_temp[0];
 		end
 	end else begin
-		oam_data <= oam[oam_addr]; // Keep it available in case it's read
+		oam_data <= oam[oam_read_addr]; // Keep it available in case it's read
 	end
 
-	// OAMADDR is set to 0 during each of ticks 257-320 (the sprite tile loading interval) of the pre-render
-	// and visible scanlines.
-	if (oam_state == STATE_FETCH && rendering)
-		oam_addr <= 0;
+	// Once started, this continues regardless of rendering status.
+	if (|eval_count && secondary_write) begin // The evaluation counter and it's subsequent increment of the oam_secondary_address seems to increment even when not rendering
+		eval_count <= eval_count + 2'd1;
+		if (~oam_secondary_ovr) begin
+			{oam_secondary_ovr, oam_secondary_addr} <= {1'b0, oam_secondary_addr} + 6'd1;
+		end else begin
+			overflow <= 1; // Overflow is set each tick of the eval SR
+		end
+	end
 
-	// XXX: This delay is nessisary probably because the OAM handling is a cycle early
-	spr_overflow <= overflow;
-
-	if (is_vbe && cycle == 340) begin
+	if (clear_signal) begin
 		overflow <= 0;
-		spr_overflow <= 0;
 	end
 
 	// Writes to OAMDATA during rendering (on the pre-render line and the visible lines 0-239,
@@ -754,16 +805,22 @@ end else if (ce) begin
 	// writes during rendering.
 	if (oam_data_write) begin
 		if (~rendering) begin
-			oam[oam_addr] <= (oam_addr[1:0] == 2'b10) ? (oam_din & 8'hE3) : oam_din; // byte 3 has no bits 2-4
-			oam_data <= (oam_addr[1:0] == 2'b10) ? (oam_din & 8'hE3) : oam_din;
+			oam[oam_read_addr] <= (is_attr_byte) ? (oam_din & 8'hE3) : oam_din; // byte 3 has no bits 2-4
+			oam_data <= oam_din;
 			oam_addr <= oam_addr + 1'b1;
 		end else begin
-			oam_addr <= (oam_addr + 8'd4) & 8'hFC;
+			oam_addr <= {oam_addr[7:2] + 6'd1, 2'b00};
 		end
 	end
 
 	if (oam_addr_write) begin
 		oam_addr <= oam_din;
+	end
+
+	// Clearing takes precedence over setting
+	if (clear_secondary_addr) begin
+		oam_secondary_addr <= 0;
+		oam_secondary_ovr <= 0;
 	end
 
 end
@@ -778,27 +835,28 @@ endmodule
 module SpriteAddressGen(
 	input clk,
 	input ce,
+	input rendering,
 	input enabled,          // If unset, |load| will be all zeros.
 	input obj_size,         // 0: Sprite Height 8, 1: Sprite Height 16.
 	input obj_patt,         // Object pattern table selection
+	input in_range,         // If a y byte is in scanline range
 	input [8:0] scanline,
-	input [2:0] cycle,      // Current load cycle. At #4, first bitmap byte is loaded. At #6, second bitmap byte is.
 	input [7:0] temp,       // Input temp data from SpriteTemp. #0 = Y Coord, #1 = Tile, #2 = Attribs, #3 = X Coord
 	output [12:0] vram_addr,// Low bits of address in VRAM that we'd like to read.
 	input [7:0] vram_data,  // Byte of VRAM in the specified address
 	output [3:0] load,      // Which subset of load_in that is now valid, will be loaded into SpritesGen.
 	output [26:0] load_in   // Bits to load into SpritesGen.
 );
-
+reg [2:0] count;
 reg [7:0] temp_tile;    // Holds the tile that we will get
 reg [3:0] temp_y;       // Holds the Y coord (will be swapped based on FlipY).
 reg flip_x, flip_y;     // If incoming bitmap data needs to be flipped in the X or Y direction.
-wire load_y =    (cycle == 0);
-wire load_tile = (cycle == 1);
-wire load_attr = (cycle == 2) && enabled;
-wire load_x =    (cycle == 3) && enabled;
-wire load_pix1 = (cycle == 5) && enabled;
-wire load_pix2 = (cycle == 7) && enabled;
+wire load_y =    (count == 0) && enabled;
+wire load_tile = (count == 1) && enabled;
+wire load_attr = (count == 2) && enabled;
+wire load_x =    (count == 3) && enabled;
+wire load_pix1 = (count == 5) && enabled;
+wire load_pix2 = (count == 7) && enabled;
 reg dummy_sprite; // Set if attrib indicates the sprite is invalid.
 
 // Flip incoming vram data based on flipx. Zero out the sprite if it's invalid. The bits are already flipped once.
@@ -817,14 +875,18 @@ assign load_in = {vram_f, vram_f, temp, temp[1:0], temp[5]};
 // index value determines pattern table selection. The lower 3 bits of the
 // range result value are always used as the fine vertical offset into the
 // selected pattern.
-assign vram_addr = {obj_size ? temp_tile[0] : obj_patt,
-										temp_tile[7:1], obj_size ? y_f[3] : temp_tile[0], cycle[1], y_f[2:0] };
+assign vram_addr = {obj_size ? temp_tile[0] : obj_patt, temp_tile[7:1], obj_size ? y_f[3] : temp_tile[0], count[1], y_f[2:0]};
 wire [7:0] scanline_y = scanline[7:0] - temp;
 always @(posedge clk) if (ce) begin
-	if (load_y) temp_y <= scanline_y[3:0];
+	if (!enabled)
+		count <= 3'd0;
+	else
+		count <= count + 3'd1;
+
+	if (load_y) begin temp_y <= scanline_y[3:0]; dummy_sprite <= ~in_range; end
 	if (load_tile) temp_tile <= temp;
-	if (load_attr) {flip_y, flip_x, dummy_sprite} <= {temp[7:6], temp[4]};
-end
+	if (load_attr) {flip_y, flip_x} <= {temp[7:6]};
+	end
 
 endmodule  // SpriteAddressGen
 
@@ -833,11 +895,11 @@ endmodule  // SpriteAddressGen
 module SpriteAddressGenEx(
 	input clk,
 	input ce,
+	input rendering,
 	input enabled,          // If unset, |load| will be all zeros.
 	input obj_size,         // 0: Sprite Height 8, 1: Sprite Height 16.
 	input obj_patt,         // Object pattern table selection
 	input [7:0] scanline,
-	input [2:0] cycle,      // Current load cycle. At #4, first bitmap byte is loaded. At #6, second bitmap byte is.
 	input [31:0] temp,      // Input temp data from SpriteTemp. #0 = Y Coord, #1 = Tile, #2 = Attribs, #3 = X Coord
 	input [7:0] vram_data,  // Byte of VRAM in the specified address
 	output [12:0] vram_addr,// Low bits of address in VRAM that we'd like to read.
@@ -846,14 +908,15 @@ module SpriteAddressGenEx(
 	output use_ex,          // If extra sprite address should be used
 	input masked_sprites
 );
+reg [2:0] count;
 
 // We keep an odd structure here to maintain compatibility with the existing sprite modules
 // which are constrained by the behavior of the original system.
-wire load_tile = (cycle == 1);
-wire load_attr = (cycle == 2) && enabled;
-wire load_x =    (cycle == 3) && enabled;
-wire load_pix1 = (cycle == 5) && enabled;
-wire load_pix2 = (cycle == 7) && enabled;
+wire load_tile = (count == 1);
+wire load_attr = (count == 2) && enabled;
+wire load_x =    (count == 3) && enabled;
+wire load_pix1 = (count == 5) && enabled;
+wire load_pix2 = (count == 7) && enabled;
 
 reg [7:0] pix1_latch, pix2_latch;
 
@@ -866,11 +929,11 @@ wire flip_x = attr[6];
 wire flip_y = attr[7];
 wire dummy_sprite = attr[4];
 
-assign use_ex = ~dummy_sprite && ~cycle[2] && ~masked_sprites;
+assign use_ex = ~dummy_sprite && ~count[2] && ~masked_sprites;
 
 // Flip incoming vram data based on flipx. Zero out the sprite if it's invalid. The bits are already flipped once.
 wire [7:0] vram_f =
-	dummy_sprite || masked_sprites ? 8'd0 :
+	(dummy_sprite || masked_sprites || ~rendering) ? 8'd0 :
 	!flip_x ? {vram_data[0], vram_data[1], vram_data[2], vram_data[3], vram_data[4], vram_data[5], vram_data[6], vram_data[7]} :
 	vram_data;
 
@@ -880,7 +943,7 @@ assign load_in = {pix1_latch, pix2_latch, load_temp, load_temp[1:0], load_temp[5
 
 wire [7:0] load_temp;
 always_comb begin
-	case (cycle)
+	case (count)
 		0: load_temp = temp_y;
 		1: load_temp = tile;
 		2: load_temp = attr;
@@ -894,9 +957,12 @@ end
 // index value determines pattern table selection. The lower 3 bits of the
 // range result value are always used as the fine vertical offset into the
 // selected pattern.
-assign vram_addr = {obj_size ? tile[0] : obj_patt,
-										tile[7:1], obj_size ? y_f[3] : tile[0], cycle[1], y_f[2:0] };
+assign vram_addr = {obj_size ? tile[0] : obj_patt, tile[7:1], obj_size ? y_f[3] : tile[0], count[1], y_f[2:0]};
 always @(posedge clk) if (ce) begin
+	if (!enabled)
+		count <= 3'd0;
+	else
+		count <= count + 3'd1;
 	if (load_tile) pix1_latch <= vram_f;
 	if (load_x) pix2_latch <= vram_f;
 end
@@ -905,12 +971,15 @@ endmodule  // SpriteAddressGen
 
 module BgPainter(
 	input clk,
-	input ce,
+	input pclk0,
 	input clear,
 	input enable,             // Shift registers activated
-	input [2:0] cycle,
+	input latch_nametable,
+	input latch_attrtable,
+	input latch_pattern1,
+	input latch_pattern2,
 	input [2:0] fine_x_scroll,
-	input [14:0] loopy,
+	input [14:0] vram_v,
 	output [7:0] name_table,  // VRAM name table to read next.
 	input [7:0] vram_data,
 	output [3:0] pixel
@@ -935,25 +1004,28 @@ initial begin
 	bg0 = 0;
 end
 
-always @(posedge clk) if (ce) begin
+always @(posedge clk) if (pclk0) begin
 	if (enable) begin
-		case (cycle[2:0])
-			1: current_name_table <= vram_data;
-			3: current_attribute_table <=
-				(!loopy[1] && !loopy[6]) ? vram_data[1:0] :
-				( loopy[1] && !loopy[6]) ? vram_data[3:2] :
-				(!loopy[1] &&  loopy[6]) ? vram_data[5:4] :
-				vram_data[7:6];
+		if (latch_nametable)
+			current_name_table <= vram_data;
 
-			5: bg0 <= vram_data; // Pattern table bitmap #0
-			//7: bg1 <= vram_data; // Pattern table bitmap #1
-		endcase
+		if (latch_attrtable) begin
+			current_attribute_table <=
+				(!vram_v[1] && !vram_v[6]) ? vram_data[1:0] :
+				( vram_v[1] && !vram_v[6]) ? vram_data[3:2] :
+				(!vram_v[1] &&  vram_v[6]) ? vram_data[5:4] :
+				vram_data[7:6];
+		end
+
+		if (latch_pattern1)
+			bg0 <= vram_data; // Pattern table bitmap #0
+
 		playfield_pipe_1[14:0] <= playfield_pipe_1[15:1];
 		playfield_pipe_2[14:0] <= playfield_pipe_2[15:1];
 		playfield_pipe_3[7:0] <= playfield_pipe_3[8:1];
 		playfield_pipe_4[7:0] <= playfield_pipe_4[8:1];
-		// Load the new values into the shift registers at the last pixel.
-		if (cycle[2:0] == 7) begin
+
+		if (latch_pattern2) begin
 			playfield_pipe_1[15:8] <= {bg0[0], bg0[1], bg0[2], bg0[3], bg0[4], bg0[5], bg0[6], bg0[7]};
 			playfield_pipe_2[15:8] <= {bg1[0], bg1[1], bg1[2], bg1[3], bg1[4], bg1[5], bg1[6], bg1[7]};
 			playfield_pipe_3[8] <= current_attribute_table[0];
@@ -983,18 +1055,18 @@ endmodule  // BgPainter
 
 
 module PixelMuxer(
-	input [3:0] bg,
-	input [3:0] obj,
-	input obj_prio,
-	output [3:0] out,
-	output is_obj
+	input  logic [3:0] bg,
+	input  logic [3:0] obj,
+	input  logic       obj_prio,
+	output logic [4:0] out,
+	output logic       is_obj
 );
 
-wire bg_flag = bg[0] | bg[1];
-wire obj_flag = obj[0] | obj[1];
+wire bg_valid = |bg[1:0];
+wire obj_valid = |obj[1:0];
 
-assign is_obj = !(obj_prio && bg_flag) && obj_flag;
-assign out = is_obj ? obj : bg;
+assign is_obj = obj_valid && ~(obj_prio && bg_valid);
+assign out = (bg_valid | obj_valid) ? (is_obj ? {1'b1, obj} : {1'b0, bg}) : 5'd0;
 
 endmodule
 
@@ -1040,9 +1112,6 @@ reg [5:0] palette [32];
 //	6'h00, 6'h20, 6'h2C, 6'h08
 //};
 
-// Force read from backdrop channel if reading from any addr 0.
-// Do this to the input, not here
-//wire [4:0] addr2 = (addr[1:0] == 0) ? 5'd0 : addr;
 // If 0x0,4,8,C: mirror every 0x10
 wire [4:0] addr2 = (addr[1:0] == 0) ? {1'b0, addr[3:0]} : addr;
 assign dout = palette[addr2];
@@ -1071,10 +1140,64 @@ end
 
 endmodule  // PaletteRam
 
+module debug_dots(
+	input enable,
+	input [5:0] color,
+	input custom1,
+	input custom2,
+	input w2000,
+	input w2001,
+	input r2002,
+	input w2003,
+	input r2004,
+	input w2004,
+	input w2005,
+	input w2006,
+	input r2007,
+	input w2007,
+	output [5:0] new_color
+);
+
+always_comb begin
+	new_color = color;
+	if (enable) begin
+		if (custom1)
+			new_color = 6'h31;
+		else if (custom2)
+			new_color = 6'h34;
+		else if (w2000)
+			new_color = 6'h16;
+		else if (w2001)
+			new_color = 6'h03;
+		else if (r2002)
+			new_color = 6'h17;
+		else if (w2003)
+			new_color = 6'h15;
+		else if (r2004)
+			new_color = 6'h09;
+		else if (w2004)
+			new_color = 6'h28;
+		else if (w2005)
+			new_color = 6'h1A;
+		else if (w2006)
+			new_color = 6'h12;
+		else if (r2007)
+			new_color = 6'h21;
+		else if (w2007)
+			new_color = 6'h06;
+	end
+end
+
+endmodule
+
+
 module PPU(
 	input         clk,
+	input         cs,
+	input         RWn,
 	input         rst_behavior,
 	input         ce,
+	input         debug_dots,
 	input         reset,            // input clock  21.48 MHz / 4. 1 clock cycle = 1 pixel
 	input         cold_reset,       // power cycle
 	inout   [1:0] sys_type,         // System type. 0 = NTSC 1 = PAL 2 = Dendy 3 = Vs.
@@ -1088,13 +1211,17 @@ module PPU(
 	output        vram_r,           // read from vram active
 	output        vram_r_ex,        // use extra sprite address
 	output        vram_w,           // write to vram active
-	output [13:0] vram_a,           // vram address
+	output [13:0] vram_addr,        // vram address
 	output [13:0] vram_a_ex,        // vram address for extra sprites
-	input   [7:0] vram_din,         // vram input
+	input   [7:0] vram_dbus_in,     // vram input
 	output  [7:0] vram_dout,
 	output  [8:0] scanline,
 	output  [8:0] cycle,
-	output reg [2:0] emphasis,
+	output  [2:0] emphasis,
+	output        hsync,
+	output        vsync,
+	output        hblank,
+	output        vblank,
 	output        short_frame,
 	input         extra_sprites,
 	input  [1:0]  mask,
@@ -1127,6 +1254,20 @@ wire [63:0] SS_PPU_DECAY_BACK;
 eReg_SavestateV #(SSREG_INDEX_PPU_1, SSREG_DEFAULT_PPU_1) iREG_SAVESTATE_PPU       (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[0], SS_PPU_BACK,       SS_PPU);
 eReg_SavestateV #(SSREG_INDEX_PPU_2, SSREG_DEFAULT_PPU_2) iREG_SAVESTATE_PPU_DECAY (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_wired_or[1], SS_PPU_DECAY_BACK, SS_PPU_DECAY);
 
+// wire cs_w = !RWn && cs;
+// wire cs_r = RWn && cs;
+
+// wire w2000 = cs_w && (ain == 3'd0);
+// wire w2001 = cs_w && (ain == 3'd1);
+// wire r2002 = cs_r && (ain == 3'd2);
+// wire r2003 = cs_r && (ain == 3'd3);
+// wire r2004 = cs_r && (ain == 3'd4);
+// wire w2004 = cs_w && (ain == 3'd4);
+// wire w2005 = cs_w && (ain == 3'd5);
+// wire w2006 = cs_w && (ain == 3'd6);
+// wire r2007 = cs_r && (ain == 3'd7);
+// wire w2007 = cs_w && (ain == 3'd7);
+
 // These are stored in control register 0
 reg obj_patt; // Object pattern table
 reg bg_patt;  // Background pattern table
@@ -1139,6 +1280,8 @@ reg grayscale; // Disable color burst
 reg playfield_clip;     // 0: Left side 8 pixels playfield clipping
 reg object_clip;        // 0: Left side 8 pixels object clipping
 
+wire in_range;
+
 initial begin
 	obj_patt = 0;
 	bg_patt = 0;
@@ -1149,7 +1292,7 @@ initial begin
 	object_clip = 0;
 	enable_playfield = 0;
 	enable_objects = 0;
-	emphasis = 0;
+	emph_reg = 0;
 	clear = 0;
 end
 
@@ -1166,19 +1309,30 @@ wire is_pre_render_line;  // True while we're on the pre render scanline
 
 reg enable_playfield, enable_objects;
 
-wire rendering_enabled = enable_objects | enable_playfield;
-assign render_ena_out = rendering_enabled;
+// Rendering_enabled is mostly part of the timing signals, which then get propagated. we know that
+// the spr/bg enabled registers don't apply til the write ends, and then all timing signals but one
+// then have to go through a pclk1, so that's 1-2 cycles to apply, then +1 (or more) for everything
+// except skip_dot calculation.
+reg [2:0] re_sr; // rendering enable shift register
+wire rendering_enabled = re_sr[1];
+wire rendering_regs = enable_objects | enable_playfield;
+assign render_ena_out = rendering_regs;
 
 // 2C02 has an "is_vblank" flag that is true from pixel 0 of line 241 to pixel 0 of line 0;
 wire is_rendering = rendering_enabled && (scanline < 240 || is_pre_render_line);
 wire is_vbe_sl;
+
+wire clear_signal = is_pre_render_line;
+
+wire [13:0] vram_a;
+reg [7:0] vram_a_byte;
 
 ClockGen clock(
 	.clk                 (clk),
 	.ce                  (ce),
 	.reset               (reset),
 	.sys_type            (sys_type),
-	.is_rendering        (rendering_enabled),
+	.is_rendering        (rendering_regs),
 	.scanline            (scanline),
 	.cycle               (cycle),
 	.is_in_vblank        (is_in_vblank),
@@ -1189,7 +1343,11 @@ ClockGen clock(
 	.is_pre_render       (is_pre_render_line),
 	.short_frame         (short_frame),
 	.is_vbe_sl           (is_vbe_sl),
-	.evenframe				(evenframe),
+	.evenframe           (evenframe),
+	.hsync               (hsync),
+	.vsync               (vsync),
+	.hblank              (hblank),
+	.vblank              (vblank),
 	// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ),
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
@@ -1199,23 +1357,24 @@ ClockGen clock(
 );
 defparam clock.USE_SAVESTATE = 1;
 
-// The loopy module handles updating of the loopy address
-wire [14:0] loopy;
+// The vram module handles updating of the vram address
+wire [14:0] vram;
 wire [2:0] fine_x_scroll;
 
-LoopyGen loopy0(
+VramAddressGen vram0(
 	.clk           (clk),
 	.ce            (ce),
 	.reset         (reset),
 	.clear         (clear),
 	.is_rendering  (is_rendering),
 	.ain           (ain),
-	.din           (din),
+	.din           (ppu_dbus),
 	.read          (read),
 	.write         (write),
 	.is_pre_render (is_pre_render_line),
+	.trigger_2007  (vram_w_ppudata_d || vram_r_ppudata_d),
 	.cycle         (cycle),
-	.loopy         (loopy),
+	.vram          (vram),
 	.fine_x_scroll (fine_x_scroll),
 	 // savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ),
@@ -1226,29 +1385,36 @@ LoopyGen loopy0(
 );
 
 // Set to true if the current ppu_addr pointer points into palette ram.
-wire is_pal_address = (loopy[13:8] == 6'b111111);
+wire is_pal_address = (vram[13:8] == 6'b111111);
 
 // Paints background
 wire [7:0] bg_name_table;
 wire [3:0] bg_pixel_noblank;
 
-wire bgp_en = (!cycle[8] || (cycle >= 320 && !at_last_cycle_group)) && is_rendering;
+wire in_visible_frame = (scanline < 240 || is_pre_render_line) && cycle > 0 && cycle < 257;
+wire out_of_clip = cycle > 8'd8;
+
+// Cycle 0 is excluded because the H_LT_256R signal is delayed by a pixel, so 0 is missed.
+wire bgp_en = ((in_visible_frame || (cycle >= 321 && cycle <= 336))) && rendering_enabled;
 
 BgPainter bg_painter(
-	.clk           (clk),
-	.ce            (ce),
-	.clear         (cycle == 319),
-	.enable        (bgp_en),
-	.cycle         (cycle[2:0]),
-	.fine_x_scroll (fine_x_scroll),
-	.loopy         (loopy),
-	.name_table    (bg_name_table),
-	.vram_data     (vram_din),
-	.pixel         (bg_pixel_noblank)
+	.clk            (clk),
+	.pclk0          (ce),
+	.clear          (reset),
+	.latch_nametable(cycle[2:0] == 2),
+	.latch_attrtable(cycle[2:0] == 4),
+	.latch_pattern1 (cycle[2:0] == 6),
+	.latch_pattern2 (cycle[2:0] == 0),
+	.enable         (bgp_en),
+	.fine_x_scroll  (fine_x_scroll),
+	.vram_v         (vram),
+	.name_table     (bg_name_table),
+	.vram_data      (vram_din),
+	.pixel          (bg_pixel_noblank)
 );
 
 // Blank out BG in the leftmost 8 pixels
-wire show_bg_on_pixel = (playfield_clip || (cycle[7:3] != 0)) && enable_playfield;
+wire show_bg_on_pixel = (playfield_clip || out_of_clip) && enable_playfield;
 wire [3:0] bg_pixel = {bg_pixel_noblank[3:2], show_bg_on_pixel ? bg_pixel_noblank[1:0] : 2'b00};
 
 wire [31:0] oam_bus_ex;
@@ -1258,16 +1424,19 @@ OAMEval spriteeval (
 	.clk               (clk),
 	.ce                (ce),
 	.reset             (reset),
+	.end_of_line       (end_of_line),
 	.rendering_enabled (rendering_enabled),
 	.obj_size          (obj_size),
 	.scanline          (scanline),
 	.cycle             (cycle),
+	.clear_signal      (clear_signal),
 	.oam_bus           (oam_bus),
 	.oam_bus_ex        (oam_bus_ex),
 	.oam_addr_write    (write && (ain == 3)),
 	.oam_data_write    (write && (ain == 4)),
-	.oam_din           (din),
-	.spr_overflow      (sprite_overflow),
+	.oam_din           (ppu_dbus),
+	.in_range          (in_range),
+	.overflow          (sprite_overflow),
 	.sprite0           (obj0_on_line),
 	.is_vbe            (is_vbe_sl),
 	.PAL               (sys_type[0]),
@@ -1295,17 +1464,20 @@ wire [12:0] sprite_vram_addr;
 wire is_obj0_pixel;            // True if obj_pixel originates from sprite0.
 wire [3:0] spriteset_load;     // Which subset of the |load_in| to load into SpriteSet
 wire [26:0] spriteset_load_in; // Bits to load into SpriteSet
+reg [2:0] emph_reg;
 
-// Between 256..319 (64 cycles), fetches bitmap data for the 8 sprites and fills in the SpriteSet
+// Between 257..320 (64 cycles), fetches bitmap data for the 8 sprites and fills in the SpriteSet
 // so that it can start drawing on the next frame.
+wire sprite_load_en = (cycle >= 257 && cycle < 321);
 SpriteAddressGen address_gen(
 	.clk       (clk),
 	.ce        (ce),
-	.enabled   (cycle[8] && !cycle[6]),  // Load sprites between 256..319
+	.rendering (rendering_enabled),
+	.in_range  (in_range & rendering_enabled),
+	.enabled   (sprite_load_en),  // Load sprites between 256..319
 	.obj_size  (obj_size),
 	.scanline  (scanline),
 	.obj_patt  (obj_patt),               // Object size and pattern table
-	.cycle     (cycle[2:0]),             // Cycle counter
 	.temp      (is_pre_render_line || ~is_rendering ? 8'hFF : oam_bus),                // Info from temp buffer.
 	.vram_addr (sprite_vram_addr),       // [out] VRAM Address that we want data from
 	.vram_data (vram_din),               // [in] Data at the specified address
@@ -1321,11 +1493,11 @@ wire use_ex;
 SpriteAddressGenEx address_gen_ex(
 	.clk            (clk),
 	.ce             (ce),
-	.enabled        (cycle[8] && !cycle[6]),  // Load sprites between 256..319
+	.rendering      (rendering_enabled),
+	.enabled        (sprite_load_en),  // Load sprites between 256..319
 	.obj_size       (obj_size),
 	.scanline       (scanline[7:0]),
 	.obj_patt       (obj_patt),               // Object size and pattern table
-	.cycle          (cycle[2:0]),             // Cycle counter
 	.temp           (is_pre_render_line || ~is_rendering ? 32'hFFFFFFFF : oam_bus_ex),                // Info from temp buffer.
 	.vram_addr      (sprite_vram_addr_ex),    // [out] VRAM Address that we want data from
 	.vram_data      (vram_din),               // [in] Data at the specified address
@@ -1335,12 +1507,13 @@ SpriteAddressGenEx address_gen_ex(
 	.masked_sprites (masked_sprites)
 );
 
-// Between 0..255 (256 cycles), draws pixels.
-// Between 256..319 (64 cycles), will be populated for next line
+// Between 1..256 (256 cycles), draws pixels.
+// Between 257..320 (64 cycles), will be populated for next line
 SpriteSet sprite_gen(
 	.clk           (clk),
 	.ce            (ce),
-	.enable        (!cycle[8]),
+	.enable        (in_visible_frame /*&& rendering_enabled*/),
+	.rendering     (rendering_enabled),
 	.load          (spriteset_load),
 	.load_in       (spriteset_load_in),
 	.load_ex       (spriteset_load_ex),
@@ -1351,35 +1524,38 @@ SpriteSet sprite_gen(
 );
 
 // Blank out obj in the leftmost 8 pixels?
-wire show_obj_on_pixel = (object_clip || (cycle[7:3] != 0)) && enable_objects;
+wire show_obj_on_pixel = (object_clip || out_of_clip) && enable_objects;
 wire [4:0] obj_pixel = {obj_pixel_noblank[4:2], show_obj_on_pixel ? obj_pixel_noblank[1:0] : 2'b00};
 
 reg sprite0_hit_bg;            // True if sprite#0 has collided with the BG in the last frame.
 
 assign SS_PPU_BACK[0] = sprite0_hit_bg;
 
-always @(posedge clk) begin
-	if (SaveStateBus_load) begin
-		sprite0_hit_bg <= SS_PPU[0];
-	end else if (ce) begin
-		if (cycle == 340 && is_vbe_sl) begin
-			sprite0_hit_bg <= 0;
-		end else if (
-			is_rendering        &&    // Object rendering is enabled
-			!cycle[8]           &&    // X Pixel 0..255
-			cycle[7:0] != 255   &&    // X pixel != 255
+wire spr0_hit = is_rendering        &&    // Object rendering is enabled
+			in_visible_frame    &&    // X Pixel 0..255
+			cycle[8:0] != 256   &&    // X pixel != 255
 			!is_pre_render_line &&    // Y Pixel 0..239
 			obj0_on_line        &&    // True if sprite#0 is included on the scan line.
 			is_obj0_pixel       &&    // True if the pixel came from tempram #0.
 			show_obj_on_pixel   &&
-			bg_pixel[1:0] != 0) begin // Background pixel nonzero.
+			bg_pixel[1:0] != 0        // Background pixel nonzero
+			;
 
-				sprite0_hit_bg <= 1;
+always @(posedge clk) begin
+	if (SaveStateBus_load) begin
+		sprite0_hit_bg <= SS_PPU[0];
+	end else if (ce) begin
+		if (clear_signal) begin
+			sprite0_hit_bg <= 0;
+		end else if (spr0_hit) begin
+			sprite0_hit_bg <= 1;
 		end
 	end
 end
 
-wire [3:0] pixel;
+
+
+wire [4:0] pixel;
 wire pixel_is_obj;
 
 PixelMuxer pixel_muxer(
@@ -1394,50 +1570,129 @@ PixelMuxer pixel_muxer(
 
 assign vram_a_ex = {1'b0, sprite_vram_addr_ex};
 
+// Vram Address timing:
+// cycle 0 *special behavior
+// Cycle 1-260 and 321 to 340 the background is fetched
+// ON Cycle[2:0] == 1 and 2, Nametable fetch
+// ON Cycle[2:0] == 3 and 4, Attribute Fetch
+// ON Cycle[2:0] == 5 and 6, Background LSBs
+// On Cycle[2:0] == 7 and 0, Background MSBs.
+// The reads take two cycles and should begin on the odd cycles setting the address and get the data on the even cycles.
+
+// Between cycles 261 through 320, the sprites are fetched
+// ON Cycle[2:0] == 1 and 2, Sprite LSB's
+// ON Cycle[2:0] == 3 and 4, Sprite MSB's
+// ON Cycle[2:0] == 5 and 6, Dummy Nametable
+// On Cycle[2:0] == 7 and 0, Dummy Attributes
+
+// It is important to note that on FPGA's, what happens ON a clock enable is the cycle-1 of when the
+// result of the action is observed. So if you do something on (cycle == 0 && ce) that means the action
+// is observed on what documentation would call cycle == 1, because cycle increments on CE as well.
+// However, combinational logic is instant, not delayed.
+
+// The actual logic for reading vram stuff is as follows, with latching following by one ppu cycle.
+// For context, t2 means the signal delayed by 2 half-ppu-cycles (one full ppu cycle).
+// wire load_nametable = ~(is_rendering && (((t2[H_LT_256R] || t2[H_EQ_320_TO_335R]) && t2[H_MOD8_2_OR_3R]) || hpos[2][2]));
+// wire load_attrtable = t2[H_MOD8_2_OR_3R] && (t2[H_LT_256R] || t2[H_EQ_320_TO_335R]);
+// wire load_pattern1 = t2[H_MOD8_4_OR_5R];
+// wire load_pattern2 = t2[H_MOD8_6_OR_7R];
+// wire load_sprites = t3[H_EQ_256_TO_319R];
+// wire load_sprnt = is_rendering && hpos[2][2];
+
+wire special_dot = ~evenframe && cycle == 0 && scanline == 0; // This dot is skipped on even frames
+
+wire nametable_read = cycle[2:0] == 1 || cycle[2:0] == 2 || cycle > 336 || special_dot;
+wire attribute_read = cycle[2:0] == 3 || cycle[2:0] == 4;
+wire pattern_table_upper = cycle[1:0] == 3 || cycle[1:0] == 0;
+wire read_cycle = ~cycle[0];
+
 always_comb begin
 	if (~is_rendering) begin
-		vram_a = loopy[13:0];
+		vram_a = vram[13:0];
 		vram_r_ex = 0;
 	end else begin
 		// Extra sprite fetch override flag
-		if (cycle[8] && !cycle[6])
+		if (sprite_load_en) // Fetch Extra sprites during dummy reads of sprite loadout
 			vram_r_ex = use_ex && extra_sprites;
 		else
 			vram_r_ex = 0;
-		if (cycle == 340)
-			vram_a = {1'b0, bg_patt, bg_name_table, cycle[1], loopy[14:12]}; // Pattern table override
-		else if (cycle[2:1] == 0 || at_last_cycle_group)
-			vram_a = {2'b10, loopy[11:0]};                                   // Name Table
-		else if (cycle[2:1] == 1)
-			vram_a = {2'b10, loopy[11:10], 4'b1111, loopy[9:7], loopy[4:2]}; // Attribute table
-		else if (cycle[8] && !cycle[6])
-			vram_a = {1'b0, sprite_vram_addr};                               // Sprite data
+
+		if (nametable_read)
+			vram_a = {2'b10, vram[11:0]};                                 // Name Table
+		else if (attribute_read)
+			vram_a = {2'b10, vram[11:10], 4'b1111, vram[9:7], vram[4:2]}; // Attribute table
+		else if (sprite_load_en)
+			vram_a = {1'b0, sprite_vram_addr};                            // Sprite pattern table during sprite loadout
 		else
-			vram_a = {1'b0, bg_patt, bg_name_table, cycle[1], loopy[14:12]}; // Pattern table
+			vram_a = {1'b0, bg_patt, bg_name_table, pattern_table_upper, vram[14:12]}; // Background pattern table otherwise
 	end
 end
 
 // Read from VRAM, either when user requested a manual read, or when we're generating pixels.
-wire vram_r_ppudata = read && (ain == 7);
+wire vram_r_ppudata = read_2007_delayed[2];
+wire vram_r_ppudata_d = read_2007_delayed[3];
+wire vram_w_ppudata = write_2007_delayed[2];
+wire vram_w_ppudata_d = write_2007_delayed[3];
 
-assign vram_r = vram_r_ppudata || is_rendering && cycle[0] == 1;
+wire ALE = (is_rendering && ~read_cycle) | (read_2007_delayed[1] || write_2007_delayed[1]);
 
-// Write to VRAM?
-assign vram_w = write && (ain == 7) && !is_pal_address && !is_rendering;
+wire [7:0] vram_din = vram_r ? vram_dbus_in : (vram_w ? vram_dout : (ALE ? vram_a[7:0] : vram_dbus_in));
 
+// The true and proper logic is that it will read if rendering is enabled and the previous cycle was odd.
+// this is important when you go from 340->0 or 339->0.
+assign vram_r = vram_r_ppudata | (is_rendering && read_cycle && (cycle != 0 || special_dot));
+assign vram_w = ~vram_r && vram_w_ppudata && !is_pal_address; // R&W at the same time should yield to read most of the time
+
+// Value currently being written to video ram
+assign vram_dout = ALE ? vram_a[7:0] : ppu_dbus;
+
+// One cycle after vram_r was asserted, the value
+// is available on the bus.
+reg vram_read_delayed;
+
+assign SS_PPU_BACK[21:14] = vram_latch;
+assign SS_PPU_BACK[   22] = vram_read_delayed;
+assign SS_PPU_BACK[57:50] = vram_a_byte;
+
+// For any future person who wants to understand what is going on here: the NES PPU multiplexes the
+// bottom 8 bits of the address with its ppu vram data bus. This means the data bits alternate between
+// vram_addr[7:0] and vram_dout. There is an external latch controlled by the ALE pin which assembles
+// the vram_addr into its full form. We do the latching in the PPU here instead for the sake of
+// cleanliness, but if you ever wanted to add real hardware compatible pins, you'd change this here.
+assign vram_addr = {vram_a[13:8], ALE ? vram_latch_value : vram_a_byte};
+
+wire [7:0] vram_latch_value = /*vram_r ? vram_din :*/ vram_a[7:0]; // This breaks stuff if uncommented.
+
+always @(posedge clk) begin
+	if (SaveStateBus_load) begin
+		vram_latch        <= SS_PPU[21:14];
+		vram_read_delayed <= SS_PPU[   22];
+		vram_a_byte       <= SS_PPU[57:50];
+	end else if (ce) begin
+		// If it so happens that ALE and vram_r are both asserted at the same time due to a poorly
+		// timed 2007 read, the ppu data bus will not be driven by the PPU and instead driven
+		// by the vram itself, so the external latch latches the data byte rather than the lower
+		// 8 bits of the address.
+		if (ALE) // Simulate the external latch
+			vram_a_byte <= vram_latch_value;
+		if (vram_read_delayed)
+			vram_latch <= vram_din;
+		vram_read_delayed <= vram_r_ppudata;
+	end
+end
+
+reg [5:0] color_pipe[4];
 wire [5:0] color2;
-wire [4:0] pram_addr = is_rendering ?
-	((|pixel[1:0]) ? {pixel_is_obj, pixel[3:0]} : 5'b00000) :
-	(is_pal_address ? loopy[4:0] : 5'b0000);
+wire [4:0] pram_addr = is_rendering && in_visible_frame ? pixel : (is_pal_address ? vram[4:0] : 5'b0000);
 
 PaletteRam palette_ram(
 	.clk   (clk),
 	.reset (reset),
 	.ce    (ce),
 	.addr  (pram_addr), // Read addr
-	.din   (din[5:0]),  // Value to write
+	.din   (ppu_dbus[5:0]),  // Value to write
 	.dout  (color2),    // Output color
-	.write (write && (ain == 7) && is_pal_address && ~is_rendering), // Condition for writing
+	.write (write_2007_delayed[1] && is_pal_address && ~is_rendering), // Condition for writing
 	// savestates
 	.SaveStateBus_Din  (SaveStateBus_Din ),
 	.SaveStateBus_Adr  (SaveStateBus_Adr ),
@@ -1446,17 +1701,55 @@ PaletteRam palette_ram(
 	.SaveStateBus_Dout (SaveStateBus_wired_or[5])
 );
 
-wire pal_mask = ~|scanline || cycle < 2 || cycle > 253;
+reg [4:0] write_2007_delayed;
+reg [4:0] read_2007_delayed;
+
+wire write_2001 = (write && ain == 1);
+wire pal_mask = ~|scanline || cycle < 3 || cycle > 254;
 wire auto_mask = (mask == 2'b11) && ~object_clip && ~playfield_clip;
-wire mask_left = (cycle < 8) && ((|mask && ~&mask) || auto_mask);
-wire mask_right = cycle > 247 && mask == 2'b10;
+wire mask_left = ~out_of_clip && ((|mask && ~&mask) || auto_mask);
+wire mask_right = cycle > 248 && mask == 2'b10;
+
 // PAL/Dendy masks scanline 0 and 2 pixels on each side with black.
 wire mask_pal = (|sys_type && pal_mask);
-wire [5:0] color1 = (grayscale ? {color2[5:4], 4'b0} : color2);
-assign color = (mask_right | mask_left | mask_pal) ? 6'h0E : color1;
+wire in_draw_range = ~(cycle >= 271 && cycle <= 328) && ~vblank;
+wire grayscale_bit = write_2001 ? ppu_dbus[0] : grayscale;
+wire not_grayscale = (in_draw_range || (vram_r_ppudata && is_pal_address)) && ~grayscale_bit;
 
-wire clear_nmi = (exiting_vblank | (read && ain == 2));
+debug_dots debug_d(
+	.enable     (debug_dots),
+	.color      (color0),
+	.custom1    (0),
+	.custom2    (spr0_hit),
+	.w2000      (write && ain == 0),
+	.w2001      (write && ain == 1),
+	.r2002      (read && ain == 2),
+	.w2003      (write && ain == 3),
+	.r2004      (read && ain == 4),
+	.w2004      (write && ain == 4),
+	.w2005      (write && ain == 5),
+	.w2006      (write && ain == 6),
+	.r2007      (read && ain == 7),
+	.w2007      (write && ain == 7),
+	.new_color  (color)
+);
+
+wire [5:0] color0 = (not_grayscale ? color_pipe[0] : {color_pipe[0][5:4], 4'b0});
+wire [5:0] color1 = (mask_right | mask_left | mask_pal) ? 6'h0E : color2;
+
+wire clear_nmi = (clear_signal | (read && ain == 2));
 wire set_nmi = entering_vblank & ~clear_nmi;
+
+wire [7:0] ppu_dbus =
+	write ? din :
+	read ? (
+		(ain == 2) ? {nmi_occured, (spr0_hit || sprite0_hit_bg) & ~clear_signal, sprite_overflow & ~clear_signal, latched_dout[4:0]} : // PPUSTATUS
+		(ain == 4) ? oam_bus : // OAMDATA
+		(ain == 7) ? (is_pal_address ? {latched_dout[7:6], (grayscale ? {color1[5:4], 4'b0000} : color1)} : vram_latch) : // PPUDATA
+		latched_dout) :
+	latched_dout;
+
+assign emphasis = {write_2001 ? ppu_dbus[7] : emph_reg[2], emph_reg[1], emph_reg[0]}; // behavior of 2c07 is unknown so oh well.
 
 assign SS_PPU_BACK[    1] = obj_patt;
 assign SS_PPU_BACK[    2] = bg_patt;
@@ -1467,8 +1760,9 @@ assign SS_PPU_BACK[    6] = playfield_clip;
 assign SS_PPU_BACK[    7] = object_clip;
 assign SS_PPU_BACK[    8] = enable_playfield;
 assign SS_PPU_BACK[    9] = enable_objects;
-assign SS_PPU_BACK[12:10] = emphasis;
+assign SS_PPU_BACK[12:10] = emph_reg;
 assign SS_PPU_BACK[   13] = nmi_occured;
+assign SS_PPU_BACK[36:34] = re_sr;
 
 always @(posedge clk) begin
 	if (reset) begin
@@ -1481,26 +1775,28 @@ always @(posedge clk) begin
 		object_clip      <= SS_PPU[    7]; // 0; // 2001 resets to 0
 		enable_playfield <= SS_PPU[    8]; // 0; // 2001 resets to 0
 		enable_objects   <= SS_PPU[    9]; // 0; // 2001 resets to 0
-		emphasis         <= SS_PPU[12:10]; // 0; // 2001 resets to 0
+		emph_reg         <= SS_PPU[12:10]; // 0; // 2001 resets to 0
 		nmi_occured      <= SS_PPU[   13]; // 0; // wasn't reset before!
+		re_sr            <= SS_PPU[36:34]; // 0; // rendering disabled on reset
 	end else if (ce) begin
+		re_sr <= {re_sr[1:0], rendering_regs};
 		if (write) begin
 			case (ain)
 				0: begin // PPU Control Register 1
 					// t:....BA.. ........ = d:......BA
-					obj_patt <= din[3];
-					bg_patt <= din[4];
-					obj_size <= din[5];
-					vbl_enable <= din[7];
+					obj_patt <= ppu_dbus[3];
+					bg_patt <= ppu_dbus[4];
+					obj_size <= ppu_dbus[5];
+					vbl_enable <= ppu_dbus[7];
 				end
 
 				1: begin // PPU Control Register 2
-					grayscale <= din[0];
-					playfield_clip <= din[1];
-					object_clip <= din[2];
-					enable_playfield <= din[3];
-					enable_objects <= din[4];
-					emphasis <= |sys_type ? {din[7], din[5], din[6]} : din[7:5];
+					grayscale <= ppu_dbus[0];
+					playfield_clip <= ppu_dbus[1];
+					object_clip <= ppu_dbus[2];
+					enable_playfield <= ppu_dbus[3];
+					enable_objects <= ppu_dbus[4];
+					emph_reg <= |sys_type ? {ppu_dbus[7], ppu_dbus[5], ppu_dbus[6]} : ppu_dbus[7:5];
 				end
 			endcase
 			if (clear) begin
@@ -1513,7 +1809,7 @@ always @(posedge clk) begin
 				object_clip      <= 'd0;
 				enable_playfield <= 'd0;
 				enable_objects   <= 'd0;
-				emphasis         <= 'd0;
+				emph_reg         <= 'd0;
 			end
 		end
 		// https://wiki.nesdev.com/w/index.php/NMI
@@ -1527,28 +1823,6 @@ end
 // If we're triggering a VBLANK NMI
 assign nmi = nmi_occured && vbl_enable;
 
-
-// One cycle after vram_r was asserted, the value
-// is available on the bus.
-reg vram_read_delayed;
-
-assign SS_PPU_BACK[21:14] = vram_latch;
-assign SS_PPU_BACK[   22] = vram_read_delayed;
-
-always @(posedge clk) begin
-	if (SaveStateBus_load) begin
-		vram_latch        <= SS_PPU[21:14];
-		vram_read_delayed <= SS_PPU[   22];
-	end else if (ce) begin
-		if (vram_read_delayed)
-			vram_latch <= vram_din;
-		vram_read_delayed <= vram_r_ppudata;
-	end
-end
-
-// Value currently being written to video ram
-assign vram_dout = din;
-
 // Last data on bus is persistent
 reg [7:0] latched_dout;
 
@@ -1561,14 +1835,16 @@ assign SS_PPU_BACK[   23] = refresh_high;
 assign SS_PPU_BACK[   24] = refresh_low;
 assign SS_PPU_BACK[32:25] = latched_dout;
 assign SS_PPU_BACK[   33] = clear;
-assign SS_PPU_BACK[63:34] = 30'b0; // free to be used
+assign SS_PPU_BACK[41:37] = read_2007_delayed;
+assign SS_PPU_BACK[46:42] = write_2007_delayed;
+assign SS_PPU_BACK[63:58] = 'd0; // free to be used
 
 assign SS_PPU_DECAY_BACK[23: 0] = decay_low;
 assign SS_PPU_DECAY_BACK[47:24] = decay_high;
-assign SS_PPU_DECAY_BACK[63:48] = 16'b0; // free to be use
+assign SS_PPU_DECAY_BACK[63:48] = 'd0; // free to be use
 
 always @(posedge clk) begin
-	if (ce && cycle == 340 && is_vbe_sl)
+	if (ce && clear_signal)
 		clear <= 0;
 	if (refresh_high) begin
 		decay_high <= 3221590; // aprox 600ms decay rate
@@ -1581,6 +1857,16 @@ always @(posedge clk) begin
 	end
 
 	if (ce) begin
+		// 2007 reads/writes are very special. They wait for the read to end, then
+		// enter a shift register that is high for 2 cycles 2 full cycle after the end
+		// to 3 full cycles after the end.
+		read_2007_delayed <= {read_2007_delayed[3:0], (read && (ain == 7))};
+		write_2007_delayed <= {write_2007_delayed[3:0], (write && (ain == 7))};
+
+		color_pipe <= '{color1, color_pipe[0], color_pipe[1], color_pipe[2]};
+
+		latched_dout <= ppu_dbus;
+
 		if (decay_high > 0)
 			decay_high <= decay_high - 1'b1;
 		else
@@ -1595,34 +1881,29 @@ always @(posedge clk) begin
 	if (read) begin
 		case (ain)
 			2: begin
-				latched_dout <= {nmi_occured,
-								sprite0_hit_bg,
-								sprite_overflow,
-								latched_dout[4:0]};
 				refresh_high <= 1'b1;
 			end
 
 			4: begin
-				latched_dout <= oam_bus;
+				//latched_dout <= oam_bus;
 				refresh_high <= 1'b1;
 				refresh_low <= 1'b1;
 			end
 
-			7: if (is_pal_address) begin
-					latched_dout <= {latched_dout[7:6], color1};
+			7: begin
+				if (is_pal_address) begin
 					refresh_low <= 1'b1;
 				end else begin
-					latched_dout <= vram_latch;
 					refresh_high <= 1'b1;
 					refresh_low <= 1'b1;
 				end
-			default: latched_dout <= latched_dout;
+			end
+			default: ;
 		endcase
 
 	end else if (write) begin
 		refresh_high <= 1'b1;
 		refresh_low <= 1'b1;
-		latched_dout <= din;
 	end
 
 	if (reset) begin
@@ -1635,6 +1916,8 @@ always @(posedge clk) begin
 		refresh_low  <= SS_PPU[   24];
 		latched_dout <= SS_PPU[32:25];
 		clear        <= SS_PPU[   33];
+		read_2007_delayed  <= SS_PPU[41:37];
+		write_2007_delayed <= SS_PPU[46:42];
 		decay_low    <= SS_PPU_DECAY[23: 0];
 		decay_high   <= SS_PPU_DECAY[47:24];
 	end

--- a/rtl/t65/T65.vhd
+++ b/rtl/t65/T65.vhd
@@ -13,7 +13,7 @@
 -- Ver 312 WoS January 2015
 --   Undoc opcode timing fixes for $B3 (LAX iy) and $BB (LAS ay)
 --   Added comments in MCode section to find handling of individual opcodes more easily
---   All "basic" Lorenz instruction test (individual functional checks, CPUTIMING check) work now with 
+--   All "basic" Lorenz instruction test (individual functional checks, CPUTIMING check) work now with
 --       actual FPGAARCADE C64 core (sources used: SVN version 1021).
 --
 -- Ver 305, 306, 307, 308, 309, 310, 311 WoS January 2015
@@ -120,7 +120,7 @@
 --              DI      => cpu_din_s,
 --              DO      => cpu_dout_s
 --          );
---      cpu_din_s <= cpu_dout_s when cpu_rwn_s='0' else 
+--      cpu_din_s <= cpu_dout_s when cpu_rwn_s='0' else
 --                   [....other sources from peripherals and memories...]
 --
 -- ----- IMPORTANT NOTES -----
@@ -130,7 +130,7 @@ library IEEE;
   use IEEE.std_logic_1164.all;
   use IEEE.numeric_std.all;
   use work.T65_Pack.all;
-  
+
   use work.pBus_savestates.all;
 
 entity T65 is
@@ -139,6 +139,7 @@ entity T65 is
     BCD_en  : in  std_logic := '1';             -- '0' => 2A03/2A07, '1' => others
 
     Res_n   : in  std_logic;
+    Pwr_n   : in  std_logic; -- Cold boot, power reset, must be paired with reset
     Enable  : in  std_logic;
     Clk     : in  std_logic;
     Rdy     : in  std_logic;
@@ -163,7 +164,7 @@ entity T65 is
     DEBUG   : out T_t65_dbg;
     NMI_ack : out std_logic;
     Instrnew: out std_logic;
-    -- savestates              
+    -- savestates
     SaveStateBus_Din  : in  std_logic_vector(63 downto 0);
     SaveStateBus_Adr  : in  std_logic_vector(9 downto 0);
     SaveStateBus_wren : in  std_logic;
@@ -256,30 +257,30 @@ architecture rtl of T65 is
   signal WRn_i          : std_logic;
 
   signal NMI_entered    : std_logic;
-  
+
   	-- savestates
 	signal reg_wired_or_0 : std_logic_vector(63 downto 0);
 	signal reg_wired_or_1 : std_logic_vector(63 downto 0);
 	signal reg_wired_or_2 : std_logic_vector(63 downto 0);
 
 	signal SS_1      : std_logic_vector(63 downto 0);
-	signal SS_1_BACK : std_logic_vector(63 downto 0);	
+	signal SS_1_BACK : std_logic_vector(63 downto 0);
 	signal SS_2      : std_logic_vector(63 downto 0);
-	signal SS_2_BACK : std_logic_vector(63 downto 0);	
+	signal SS_2_BACK : std_logic_vector(63 downto 0);
 	signal SS_3      : std_logic_vector(63 downto 0);
-	signal SS_3_BACK : std_logic_vector(63 downto 0);	
+	signal SS_3_BACK : std_logic_vector(63 downto 0);
 
 begin
 
-  iREG_SAVESTATE_T80_1 : entity work.eReg_SavestateV generic map (0, x"E064000000000000") port map (Clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, reg_wired_or_0, SS_1_BACK, SS_1);  
-  iREG_SAVESTATE_T80_2 : entity work.eReg_SavestateV generic map (1, x"0000012000000001") port map (Clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, reg_wired_or_1, SS_2_BACK, SS_2);  
-  iREG_SAVESTATE_T80_3 : entity work.eReg_SavestateV generic map (2, x"0000000000000000") port map (Clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, reg_wired_or_2, SS_3_BACK, SS_3);  
+  iREG_SAVESTATE_T80_1 : entity work.eReg_SavestateV generic map (0, x"E064000000000000") port map (Clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, reg_wired_or_0, SS_1_BACK, SS_1);
+  iREG_SAVESTATE_T80_2 : entity work.eReg_SavestateV generic map (1, x"0000012000000001") port map (Clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, reg_wired_or_1, SS_2_BACK, SS_2);
+  iREG_SAVESTATE_T80_3 : entity work.eReg_SavestateV generic map (2, x"0000000000000000") port map (Clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, reg_wired_or_2, SS_3_BACK, SS_3);
   SaveStateBus_Dout <= reg_wired_or_0 or reg_wired_or_1 or reg_wired_or_2;
-  
+
 
   NMI_ack <= NMIAct;
 
-  -- gate Rdy with read/write to make an "OK, it's really OK to stop the processor 
+  -- gate Rdy with read/write to make an "OK, it's really OK to stop the processor
   really_rdy <= Rdy or not(WRn_i);
   Sync <= '1' when MCycle = "000" else '0';
   EF <= EF_i;
@@ -363,23 +364,23 @@ begin
       Res_n_d <= '1';
     end if;
   end process;
-  
-  
-  SS_1_BACK(15 downto  0) <= std_logic_vector(PC);            
-  SS_1_BACK(23 downto 16) <= IR;            
+
+
+  SS_1_BACK(15 downto  0) <= std_logic_vector(PC);
+  SS_1_BACK(23 downto 16) <= IR;
   SS_1_BACK(31 downto 24) <= std_logic_vector(S(7 downto 0));
-  SS_1_BACK(39 downto 32) <= PBR;           
-  SS_1_BACK(47 downto 40) <= DBR;           
-  SS_1_BACK(49 downto 48) <= Mode_r;        
-  SS_1_BACK(          50) <= BCD_en_r;      
-  SS_1_BACK(54 downto 51) <= std_logic_vector(to_unsigned(T_ALU_Op'POS(ALU_Op_r), 4));     
-  SS_1_BACK(58 downto 55) <= std_logic_vector(to_unsigned(T_Write_Data'POS(Write_Data_r), 4));  
-  SS_1_BACK(60 downto 59) <= std_logic_vector(to_unsigned(T_Set_Addr_To'POS(Set_Addr_To_r), 2));  
-  SS_1_BACK(          61) <= WRn_i;         
-  SS_1_BACK(          62) <= EF_i;          
-  SS_1_BACK(          63) <= MF_i;          
-  SS_2_BACK(           0) <= XF_i;          
-  SS_2_BACK(           1) <= rdy_mod;          
+  SS_1_BACK(39 downto 32) <= PBR;
+  SS_1_BACK(47 downto 40) <= DBR;
+  SS_1_BACK(49 downto 48) <= Mode_r;
+  SS_1_BACK(          50) <= BCD_en_r;
+  SS_1_BACK(54 downto 51) <= std_logic_vector(to_unsigned(T_ALU_Op'POS(ALU_Op_r), 4));
+  SS_1_BACK(58 downto 55) <= std_logic_vector(to_unsigned(T_Write_Data'POS(Write_Data_r), 4));
+  SS_1_BACK(60 downto 59) <= std_logic_vector(to_unsigned(T_Set_Addr_To'POS(Set_Addr_To_r), 2));
+  SS_1_BACK(          61) <= WRn_i;
+  SS_1_BACK(          62) <= EF_i;
+  SS_1_BACK(          63) <= MF_i;
+  SS_2_BACK(           0) <= XF_i;
+  SS_2_BACK(           1) <= rdy_mod;
 
   process (Clk)
   begin
@@ -390,7 +391,7 @@ begin
         S(15 downto 8) <= (others => '0');                                             -- Dummy
         S( 7 downto 0) <= unsigned(SS_1(31 downto 24));      -- (others => '0');       -- Dummy
         PBR            <= SS_1(39 downto 32);                -- (others => '0');
-        DBR            <= SS_1(47 downto 40);                -- (others => '0');                                                    
+        DBR            <= SS_1(47 downto 40);                -- (others => '0');
         Mode_r         <= SS_1(49 downto 48);                -- (others => '0');
         BCD_en_r       <= SS_1(          50);                -- '1';
         ALU_Op_r       <= T_ALU_Op'VAL(to_integer(unsigned(SS_1(54 downto 51))));  -- ALU_OP_BIT; -- "1100"
@@ -400,9 +401,9 @@ begin
         EF_i           <= SS_1(          62);                -- '1';
         MF_i           <= SS_1(          63);                -- '1';
         XF_i           <= SS_2(           0);                -- '1';
-        
+
       elsif (SaveStateBus_load = '1') then
-      
+
         rdy_mod <= SS_2(1);
 
       elsif (Enable = '1') then
@@ -485,21 +486,25 @@ begin
 
   PCAdder <= resize(PC(7 downto 0),9) + resize(unsigned(DL(7) & DL),9) when PCAdd = '1'
          else "0" & PC(7 downto 0);
-         
+
   SS_2_BACK( 9 downto  2) <= P;
   SS_2_BACK(17 downto 10) <= ABC(7 downto 0);
-  SS_2_BACK(25 downto 18) <= X(7 downto 0);  
-  SS_2_BACK(33 downto 26) <= Y(7 downto 0);  
-  SS_2_BACK(          34) <= IRQ_n_o;        
-  SS_2_BACK(          35) <= NMI_n_o;        
-  SS_2_BACK(          36) <= SO_n_o;         
+  SS_2_BACK(25 downto 18) <= X(7 downto 0);
+  SS_2_BACK(33 downto 26) <= Y(7 downto 0);
+  SS_2_BACK(          34) <= IRQ_n_o;
+  SS_2_BACK(          35) <= NMI_n_o;
+  SS_2_BACK(          36) <= SO_n_o;
 
   process (Clk)
     variable tmpP:std_logic_vector(7 downto 0);--Lets try to handle loading P at mcycle=0 and set/clk flags at same cycle
   begin
     if Clk'event and Clk = '1' then
-      if Res_n_i = '0' then
-        P <= SS_2(9 downto 2); -- x"00"; -- ensure we have nothing set on reset      
+      if (Pwr_n = '0') then
+        ABC            <= (others => '0');
+        X              <= (others => '0');
+        Y              <= (others => '0');
+      elsif (Res_n_i = '0') then
+        P <= SS_2(9 downto 2); -- x"00"; -- ensure we have nothing set on reset
       elsif (SaveStateBus_load = '1') then
         ABC(7 downto 0) <= SS_2(17 downto 10);
         X(7 downto 0)   <= SS_2(25 downto 18);
@@ -507,6 +512,7 @@ begin
         IRQ_n_o         <= SS_2(          34);
         NMI_n_o         <= SS_2(          35);
         SO_n_o          <= SS_2(          36);
+
       elsif (Enable = '1') then
         tmpP:=P;
         if (really_rdy = '1') then
@@ -590,12 +596,12 @@ begin
 ---------------------------------------------------------------------------
 
   SS_3_BACK( 7 downto  0) <= BusA_r;
-  SS_3_BACK(15 downto  8) <= BusB;  
+  SS_3_BACK(15 downto  8) <= BusB;
   SS_3_BACK(23 downto 16) <= BusB_r;
-  SS_3_BACK(31 downto 24) <= AD;    
-  SS_3_BACK(40 downto 32) <= BAL;   
-  SS_3_BACK(48 downto 41) <= BAH;   
-  SS_3_BACK(56 downto 49) <= DL;    
+  SS_3_BACK(31 downto 24) <= AD;
+  SS_3_BACK(40 downto 32) <= BAL;
+  SS_3_BACK(48 downto 41) <= BAH;
+  SS_3_BACK(56 downto 49) <= DL;
   SS_3_BACK(          57) <= NMI_entered;
   SS_3_BACK(63 downto 58) <= (others => '0'); -- free to use
 
@@ -743,11 +749,11 @@ begin
 --
 -------------------------------------------------------------------------
 
-  SS_2_BACK(39 downto 37) <= MCycle;  
+  SS_2_BACK(39 downto 37) <= MCycle;
   SS_2_BACK(          40) <= RstCycle;
   SS_2_BACK(          41) <= IRQCycle;
   SS_2_BACK(          42) <= NMICycle;
-  SS_2_BACK(          43) <= NMIAct;  
+  SS_2_BACK(          43) <= NMIAct;
   SS_2_BACK(63 downto 44) <= (others => '0'); -- free to use
 
   Instrnew <= '1' when (MCycle = LCycle and Break = '0') else '0';
@@ -778,7 +784,7 @@ begin
             MCycle <= std_logic_vector(unsigned(MCycle) + 1);
           end if;
         end if;
-        --detect NMI even if not rdy    
+        --detect NMI even if not rdy
         if NMI_n_o = '1' and (NMI_n = '0' and (IR(4 downto 0)/="10000" or Jump/="01")) then -- branches have influence on NMI start (not best way yet, though - but works...)
           NMIAct <= '1';
         end if;

--- a/rtl/video.sv
+++ b/rtl/video.sv
@@ -213,7 +213,7 @@ always @(posedge clk) begin
 		hblank_shift <= {hblank_shift[0], hblank_out};
 		vblank_shift <= {vblank_shift[0], vblank_out};
 
-		if (h == 337 && v == 0)
+		if (h == 240 && v == 0)
 			hold_reset <= 1'b0;
 		else if (reset)
 			hold_reset <= 1'b1;

--- a/rtl/video.sv
+++ b/rtl/video.sv
@@ -9,11 +9,16 @@ module video
 	input  [5:0] color,
 	input  [8:0] count_h,
 	input  [8:0] count_v,
-	input        hide_overscan,
+	input  [1:0] hide_overscan,
 	input  [3:0] palette,
 	input  [2:0] emphasis,
 	input  [1:0] reticle,
+	input  [1:0] sys_type,
 	input        pal_video,
+	input        nes_hblank,
+	input        nes_hsync,
+	input        nes_vsync,
+	input        nes_vblank,
 
 	input        load_color,
 	input [23:0] load_color_data,
@@ -22,21 +27,33 @@ module video
 	output   reg hold_reset,
 
 	output       ce_pix,
-	output reg   HSync,
-	output reg   VSync,
-	output reg   HBlank,
-	output reg   VBlank,
+	output       HSync,
+	output       VSync,
+	output       HBlank,
+	output       VBlank,
 	output [7:0] R,
 	output [7:0] G,
 	output [7:0] B
 );
 
-reg pix_ce, pix_ce_n;
-wire [5:0] color_ef = reticle[0] ? (reticle[1] ? 6'h21 : 6'h15) : is_padding ? 6'd63 : color;
+reg vsync_reg, hsync_reg, hblank_reg, vblank_reg;
+reg [1:0] hsync_shift, vsync_shift, hblank_shift, vblank_shift;
 
-always @(negedge clk) begin
+assign HSync = hsync_shift[1];
+assign VSync = vsync_shift[1];
+assign HBlank = hblank_shift[1];
+assign VBlank = vblank_shift[1];
+
+wire hsync_out = hsync_reg | nes_hsync;
+wire vsync_out = vsync_reg | nes_vsync;
+wire hblank_out = hblank_reg | nes_hblank;
+wire vblank_out = vblank_reg | nes_vblank;
+
+reg pix_ce;
+wire [5:0] color_ef = reticle[0] ? (reticle[1] ? 6'h21 : 6'h15) : color;
+
+always @(posedge clk) begin
 	pix_ce   <= ~cnt[1] & ~cnt[0];
-	pix_ce_n <=  cnt[1] & ~cnt[0];
 end
 
 assign ce_pix = pix_ce;
@@ -117,8 +134,7 @@ reg [23:0] pixel;
 reg hbl, vbl;
 
 always @(posedge clk) begin
-	
-	if(pix_ce_n) begin
+	if(pix_ce) begin
 		case (palette)
 			0: pixel <= pal_kitrinx_lut[color_ef][23:0];
 			1: pixel <= pal_smooth_lut[color_ef][23:0];
@@ -128,139 +144,152 @@ always @(posedge clk) begin
 			5: pixel <= mem_data;
 			default:pixel <= pal_kitrinx_lut[color_ef][23:0];
 		endcase
-	
-		hbl <= hblank;
-		vbl <= vblank;
 	end
 end
 
+wire disengaged = reset || hold_reset;
 
 reg  hblank, vblank;
-reg  [9:0] h, v;
-reg  [1:0] free_sync = 0;
-wire [9:0] hc = (&free_sync | reset) ? h : count_h;
-wire [9:0] vc = (&free_sync | reset) ? v : count_v;
-wire [9:0] vsync_start = (pal_video ? 10'd270 : 10'd243);
+reg  [8:0] h, v;
+wire [8:0] hc = disengaged ? h : count_h;
+wire [8:0] vc = disengaged ? v : count_v;
+wire [8:0] vblank_start, vblank_end, hblank_start, hblank_end, hsync_start, hsync_end;
+wire [8:0] vblank_start_sl;
+wire hblank_period;
 
-always @(posedge clk) begin
-	reg [8:0] old_count_v;
-	if (h == 0 && v == 0)
-		hold_reset <= 1'b0;
-	else if (reset)
-		hold_reset <= 1'b1;
-
-	if(pix_ce_n) begin
-		if((old_count_v == 511) && (count_v == 0)) begin
-			h <= 0;
-			v <= 0;
-			free_sync <= 0;
-		end else begin
-			if(h == 340) begin
-				h <= 0;
-				if(v == (pal_video ? 311 : 261)) begin
-					v <= 0;
-					if(~&free_sync) free_sync <= free_sync + 1'd1;
-				end else begin
-					v <= v + 1'd1;
-				end
-			end else begin
-				h <= h + 1'd1;
-			end
+always_comb begin
+	case (sys_type)
+		2'b00,2'b11: begin // NTSC/Vs.
+			vblank_start_sl = 9'd241;
 		end
 
-		old_count_v <= count_v;
-	end
-
-	// The NES and SNES proper resolutions are 280 pixels wide, and 240 lines high. Only 256 of these pixels per line
-	// are drawn with image data, but the real PPU padded the rest with color 0 to make the aspect ratio correct, since
-	// they anticipated the overscan. This padding MUST be considered when scaling the image to 4:3 AR.
-	// http://wiki.nesdev.com/w/index.php?title=Overscan#For_emulator_developers
-
-	// Overscan is simply a zoom-in, and most emulators will take off 8 from the top and bottom to reach the magic
-	// number of 224 pixels, so we take off a proportional percentage from the sides to compensate.
-
-	if(pix_ce) begin
-		if(hide_overscan) begin
-			hblank <= (hc >= HBL_START && hc <= HBL_END);                  // 280 - ((224/240) * 16) = 261.3
-			vblank <= (vc > (VBL_START - 9)) || (vc < 8);                  // 240 - 16 = 224
-		end else begin
-			hblank <= (hc >= HBL_START) && (hc <= HBL_END);                // 280 pixels
-			vblank <= (vc >= VBL_START);                                   // 240 lines
-		end
-		
-		if(hc == 279) begin
-			HSync <= 1;
-			VSync <= ((vc >= vsync_start) && (vc < vsync_start+3));
+		2'b01: begin       // PAL
+			vblank_start_sl = 9'd241;
 		end
 
-		if(hc == 304) HSync <= 0;
-	end
+		2'b10: begin       // Dendy
+			vblank_start_sl = 9'd291;
+		end
+	endcase
+
+	case (hide_overscan)
+		2'b00: begin // Normal, trim to 224 lines, 256 dots
+			hblank_period = (hc >= 257 || (hc <= 9'd0));
+			vblank_start = vblank_start_sl - 9'd10;
+			vblank_end = 9'd7;
+		end
+		2'b01: begin // "full" trim to 240 lines, 256 dots
+			hblank_period = (hc >= 257 || (hc <= 9'd0));
+			vblank_start = vblank_start_sl - 9'd2;
+			vblank_end = 9'd511;
+		end
+		2'b10: begin // show border trim to 240 lines, 282 dots
+			hblank_period = (hc >= 270 && hc <= 327);
+			vblank_start = vblank_start_sl - 9'd2;
+			vblank_end = 9'd511;
+		end
+		default: begin // Just show everything for the masochists
+			hblank_period = (hc >= 270 && hc <= 326);
+			vblank_start = vblank_start_sl;
+			vblank_end = 9'd511;
+		end
+	endcase
 end
 
-localparam HBL_START = 256;
-localparam HBL_END   = 340;
-localparam VBL_START = 240;
-localparam VBL_END   = 511;
-
-wire is_padding = (hc > 255);
-
-reg dark_r, dark_g, dark_b;
+wire hsync_period = (hc >= 278 && hc <= 302);
 
 wire [7:0] ri = pixel[23:16];
 wire [7:0] gi = pixel[15:8];
 wire [7:0] bi = pixel[7:0];
-
 reg [7:0] ro,go,bo;
-always @(posedge clk) if (pix_ce_n) begin
+
+
+always @(posedge clk) begin
 	reg [2:0] emph;
-	ro <= ri;
-	go <= gi;
-	bo <= bi;
-	emph <= 0;
-	if (~&color_ef[3:1]) begin // Only applies in draw range
-		emph <= emphasis;
+
+	if (pix_ce) begin
+		hsync_shift <= {hsync_shift[0], hsync_out};
+		vsync_shift <= {vsync_shift[0], vsync_out};
+		hblank_shift <= {hblank_shift[0], hblank_out};
+		vblank_shift <= {vblank_shift[0], vblank_out};
+
+		if (h == 337 && v == 0)
+			hold_reset <= 1'b0;
+		else if (reset)
+			hold_reset <= 1'b1;
+
+		h <= h + 1'd1;
+		if (h >= 340) begin
+			h <= 0;
+			v <= v + 1'd1;
+			if (v == (pal_video ? 310 : 260))
+				v <= 9'd511;
+		end
+
+		if (count_h == 0 && count_v == 0) begin // Resync the counters in case of skipped dots
+			h <= 1;
+			v <= 0;
+		end
+
+		hsync_reg <= hsync_period;
+		hblank_reg <= hblank_period;
+
+		if (vc == (vblank_start_sl + 3'd3) && hsync_period)
+			vsync_reg <= 1;
+		if (vc == (vblank_start_sl + 3'd6) && hsync_period)
+			vsync_reg <= 0;
+
+		if (vc == vblank_start && hsync_period)
+			vblank_reg <= 1;
+		if (vc == vblank_end && hsync_period)
+			vblank_reg <= 0;
+
+		ro <= ri;
+		go <= gi;
+		bo <= bi;
+		emph <= 0;
+		if (~&color_ef[3:1]) begin // Only applies in draw range
+			emph <= emphasis;
+		end
+
+		case(emph)
+			1: begin
+					ro <= ri;
+					go <= gi - gi[7:2];
+					bo <= bi - bi[7:2];
+				end
+			2: begin
+					ro <= ri - ri[7:2];
+					go <= gi;
+					bo <= bi - bi[7:2];
+				end
+			3: begin
+					ro <= ri - ri[7:2];
+					go <= gi - gi[7:3];
+					bo <= bi - bi[7:2] - bi[7:3];
+				end
+			4: begin
+					ro <= ri - ri[7:3];
+					go <= gi - gi[7:3];
+					bo <= bi;
+				end
+			5: begin
+					ro <= ri - ri[7:3];
+					go <= gi - gi[7:2];
+					bo <= bi - bi[7:3];
+				end
+			6: begin
+					ro <= ri - ri[7:2];
+					go <= gi - gi[7:3];
+					bo <= bi - bi[7:3];
+				end
+			7: begin
+					ro <= ri - ri[7:2];
+					go <= gi - gi[7:2];
+					bo <= bi - bi[7:2];
+				end
+		endcase
 	end
-	
-	case(emph)
-		1: begin
-				ro <= ri;
-				go <= gi - gi[7:2];
-				bo <= bi - bi[7:2];
-			end
-		2: begin
-				ro <= ri - ri[7:2];
-				go <= gi;
-				bo <= bi - bi[7:2];
-			end
-		3: begin
-				ro <= ri - ri[7:2];
-				go <= gi - gi[7:3];
-				bo <= bi - bi[7:2] - bi[7:3];
-			end
-		4: begin
-				ro <= ri - ri[7:3];
-				go <= gi - gi[7:3];
-				bo <= bi;
-			end
-		5: begin
-				ro <= ri - ri[7:3];
-				go <= gi - gi[7:2];
-				bo <= bi - bi[7:3];
-			end
-		6: begin
-				ro <= ri - ri[7:2];
-				go <= gi - gi[7:3];
-				bo <= bi - bi[7:3];
-			end
-		7: begin
-				ro <= ri - ri[7:2];
-				go <= gi - gi[7:2];
-				bo <= bi - bi[7:2];
-			end
-	endcase
-	
-	HBlank <= hbl;
-	VBlank <= vbl;
 end
 
 assign R = ro;


### PR DESCRIPTION
This fixes the following issues:
#416
#412
#375
#370
#367
#366
#364
#359
#235
#192

Additionally adds support for randomizing/clearing ram on load, borders and overscan drawing, native PPU timing signals, aligned video timing on reset to prevent video desync, support for misaligned OAM, OAM corruption, and several other isosteric behaviors of the real system. Also fixed an MMC1 bug that crashed the japanese game Shinsenden.