### PR TITLE
reset state fixes for the ppu and cpu

### DIFF
--- a/rtl/regs_savestates.sv
+++ b/rtl/regs_savestates.sv
@@ -6,23 +6,23 @@ package regs_savestates;
 
 	parameter [9:0] SSREG_INDEX_PPU_1    = 10'd4;   parameter [63:0] SSREG_DEFAULT_PPU_1    = 64'h0000000000000000;
 	parameter [9:0] SSREG_INDEX_PPU_2    = 10'd5;   parameter [63:0] SSREG_DEFAULT_PPU_2    = 64'h0000000000000000;
-	parameter [9:0] SSREG_INDEX_CLOCKGEN = 10'd6;   parameter [63:0] SSREG_DEFAULT_CLOCKGEN = 64'h0000000000000152;
+	parameter [9:0] SSREG_INDEX_CLOCKGEN = 10'd6;   parameter [63:0] SSREG_DEFAULT_CLOCKGEN = 64'h0000000000000000;
 	parameter [9:0] SSREG_INDEX_PAL0     = 10'd7;   parameter [63:0] SSREG_DEFAULT_PAL0     = 64'h0008000900080000;
 	parameter [9:0] SSREG_INDEX_PAL1     = 10'd8;   parameter [63:0] SSREG_DEFAULT_PAL1     = 64'h203A040100100201;
 	parameter [9:0] SSREG_INDEX_PAL2     = 10'd9;   parameter [63:0] SSREG_DEFAULT_PAL2     = 64'h2C00003404080200;
 	parameter [9:0] SSREG_INDEX_PAL3     = 10'd10;  parameter [63:0] SSREG_DEFAULT_PAL3     = 64'h080214032C240D01;
 	parameter [9:0] SSREG_INDEX_LOOPY    = 10'd11;  parameter [63:0] SSREG_DEFAULT_LOOPY    = 64'h0000000000000000;
 	parameter [9:0] SSREG_INDEX_OAMEVAL  = 10'd12;  parameter [63:0] SSREG_DEFAULT_OAMEVAL  = 64'h00000000000001FF;
-	
+
 	parameter [9:0] SSREG_INDEX_APU_TOP  = 10'd16;  parameter [63:0] SSREG_DEFAULT_APU_TOP  = 64'h0000000000000000;
 	parameter [9:0] SSREG_INDEX_APU_DMC1 = 10'd17;  parameter [63:0] SSREG_DEFAULT_APU_DMC1 = 64'h0000000000000000;
 	parameter [9:0] SSREG_INDEX_APU_DMC2 = 10'd18;  parameter [63:0] SSREG_DEFAULT_APU_DMC2 = 64'h0000000000000000;
 	parameter [9:0] SSREG_INDEX_APU_FCT  = 10'd19;  parameter [63:0] SSREG_DEFAULT_APU_FCT  = 64'h0000000000007FFF;
-	
+
 	parameter [9:0] SSREG_INDEX_TOP      = 10'd24;  parameter [63:0] SSREG_DEFAULT_TOP      = 64'h0000000000000000;
-	
+
 	parameter [9:0] SSREG_INDEX_EXT      = 10'd28;  parameter [63:0] SSREG_DEFAULT_EXT      = 64'h0000000000000000;
-	
+
 	// mapper savestates can be used by multiple mappers, only active mapper outputs. default values for mappers are defined local!
 	parameter [9:0] SSREG_INDEX_MAP1     = 10'd32;
 	parameter [9:0] SSREG_INDEX_MAP2     = 10'd33;
@@ -30,7 +30,7 @@ package regs_savestates;
 	parameter [9:0] SSREG_INDEX_MAP4     = 10'd35;
 	parameter [9:0] SSREG_INDEX_MAP5     = 10'd36;
 	parameter [9:0] SSREG_INDEX_MAP6     = 10'd37;
-	
+
 	// additional modules for mappers in hierachy level 2
 	parameter [9:0] SSREG_INDEX_L2MAP1   = 10'd40;
 

--- a/rtl/t65/T65.vhd
+++ b/rtl/t65/T65.vhd
@@ -354,12 +354,12 @@ begin
 
   -- the 65xx design requires at least two clock cycles before
   -- starting its reset sequence (according to datasheet)
-  process (Res_n, Clk)
+  process (Res_n, Clk, Enable)
   begin
     if Res_n = '0' then
       Res_n_i <= '0';
       Res_n_d <= '0';
-    elsif Clk'event and Clk = '1' then
+    elsif Clk'event and Clk = '1' and Enable = '1' then
       Res_n_i <= Res_n_d;
       Res_n_d <= '1';
     end if;

--- a/rtl/video.sv
+++ b/rtl/video.sv
@@ -219,7 +219,7 @@ always @(posedge clk) begin
 		hblank_shift <= {hblank_shift[0], hblank_out};
 		vblank_shift <= {vblank_shift[0], vblank_out};
 
-		if (h == 240 && v == 0)
+		if (h == 0 && v == 0)
 			hold_reset <= 1'b0;
 		else if (reset)
 			hold_reset <= 1'b1;
@@ -232,8 +232,8 @@ always @(posedge clk) begin
 				v <= 9'd511;
 		end
 
-		if (count_h == 0 && count_v == 0) begin // Resync the counters in case of skipped dots
-			h <= 1;
+		if (count_h == 5 && count_v == 0) begin // Resync the counters in case of skipped dots
+			h <= 6'd0;
 			v <= 0;
 		end
 


### PR DESCRIPTION
At some point the T65 was converted to use CE's and the dummy reset cycles missed the enable signal. This also has some tweaks to scanline 0 behavior and palette corruption behavior.