### PR TITLE
Mapper 30: Implement flash writes

### DIFF
--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -197,9 +197,9 @@ Mapper28 map28(
 //*****************************************************************************//
 // Name   : UNROM 512                                                          //
 // Mappers: 30                                                                 //
-// Status : No Self Flashing/Needs testing                                     //
+// Status : Basic Self Flashing/Needs testing                                  //
 // Notes  : Homebrew mapper                                                    //
-// Games  : ?                                                                  //
+// Games  : More Glider                                                        //
 //*****************************************************************************//
 Mapper30 map30(
 	.clk        (clk),


### PR DESCRIPTION
This homebrew mapper has submappers defined with its PRG-ROM in flash memory with a routine to flash itself. The game More Glider requires writing to this flash for the continue routine (after game over) to function.

Implementation based on the PowerPak source code for this mapper found [here](https://forums.nesdev.org/viewtopic.php?p=236715#p236715) and partially tested (only basic flash writes and write protect on correct headers) with the test roms found [here](https://forums.nesdev.org/viewtopic.php?p=236442#p236442). 

These writes are not persistent like a real cart and I don't see a way to fix this or to trigger the core's `SRAM` saving routine. Use save states to record progress.

Fixes https://github.com/MiSTer-devel/NES_MiSTer/issues/435