### PR TITLE
Persistent flash saving for mappers 30 and 111

### DIFF
--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -34,6 +34,7 @@ module cart_top (
 	output reg        prg_conflict,   // PRG Data is ROM & prg_din
 	output reg        has_savestate,  // mapper supports savestates
 	output reg        prg_conflict_d0,   // PRG Data is ROM & (prg_din | 1)
+	output reg        has_flashsaves, // Homebrew mapper that saves to PRG-ROM in flash memory
 	input       [9:0] prg_mask,       // PRG Mask for SDRAM translation
 	input       [9:0] chr_mask,       // CHR Mask for SDRAM translation
 	input             chr_ex,         // chr_addr is from an extra sprite read if high
@@ -197,7 +198,7 @@ Mapper28 map28(
 //*****************************************************************************//
 // Name   : UNROM 512                                                          //
 // Mappers: 30                                                                 //
-// Status : Basic Self Flashing/Needs testing                                  //
+// Status : Self flashing except sector erase                                  //
 // Notes  : Homebrew mapper                                                    //
 // Games  : More Glider                                                        //
 //*****************************************************************************//
@@ -1215,8 +1216,8 @@ Mapper107 map107(
 //*****************************************************************************//
 // Name   : GTROM                                                              //
 // Mappers: 111                                                                //
-// Status : Passes all tests except reflash test                               //
-// Notes  : No LED or self-reflash support                                     //
+// Status : Passes all tests except flash sector erase                         //
+// Notes  : No LED or flash sector erase                                       //
 // Games  : Super Homebrew War, Candelabra: Estoscerro, more homebrew          //
 //*****************************************************************************//
 Mapper111 map111(
@@ -2415,7 +2416,12 @@ always @* begin
 	{diskside} = {fds_diskside};
 
 	// Behavior helper flags
-	{prg_conflict_d0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout} = {flags_out_b[4], flags_out_b[3], flags_out_b[2], flags_out_b[1], flags_out_b[0]};
+	has_chr_dout    = flags_out_b[0];
+	prg_bus_write   = flags_out_b[1];
+	prg_conflict    = flags_out_b[2];
+	has_savestate   = flags_out_b[3];
+	prg_conflict_d0 = flags_out_b[4];
+	has_flashsaves  = flags_out_b[5];
 
 	// Address translation for SDRAM
 	if ((prg_aout[21] == 1'b0) && (prg_aout[24] == 1'b0))

--- a/rtl/nes.v
+++ b/rtl/nes.v
@@ -133,6 +133,7 @@ module NES(
 	input         gg_reset,
 	output  [2:0] emphasis,
 	output        save_written,
+	output        mapper_has_flashsaves,
 	input         debug_dots,
 
 	// savestates
@@ -638,19 +639,22 @@ PPU ppu(
 
 wire [15:0] prg_addr = addr;
 wire [7:0] prg_din = (dbus & (prg_conflict ? cpumem_din : 8'hFF)) | (prg_conflict_d0 ? cpumem_din & 8'h01 : 8'h00);
-wire prg_conflict_d0;
 
 wire prg_read  = mr_int && cart_pre && (addr[15:5] != 11'b0100_0000_000) && !ppu_cs;
 wire prg_write = mw_int && cart_pre;
 
-wire prg_allow, prg_bus_write, prg_conflict, vram_a10, vram_ce, chr_allow;
+wire prg_allow, vram_a10, vram_ce, chr_allow;
 wire [24:0] prg_linaddr;
 wire [21:0] chr_linaddr;
 wire [7:0] prg_dout_mapper, chr_from_ppu_mapper;
-wire has_chr_from_ppu_mapper;
 wire [15:0] sample_ext;
+wire has_chr_from_ppu_mapper, prg_bus_write, prg_conflict, prg_conflict_d0, has_flashsaves;
 
-assign save_written = (mapper_flags[7:0] == 8'h14) ? (prg_linaddr[21:18] == 4'b1111 && prg_write && prg_allow) : (prg_addr[15:13] == 3'b011 && prg_write) | bram_write;
+assign save_written = has_flashsaves ? (!prg_linaddr[24] && prg_write && prg_allow) :                            // Flash save: writes to PRG-ROM
+                      (mapper_flags[7:0] == 8'h14) ? (prg_linaddr[21:18] == 4'b1111 && prg_write && prg_allow) : // Mapper 20/FDS
+                      (prg_addr[15:13] == 3'b011 && prg_write) | bram_write;                                     // Default - $6000-$7FFF or BRAM
+
+assign mapper_has_flashsaves = has_flashsaves;
 
 cart_top multi_mapper (
 	// FPGA specific
@@ -698,7 +702,8 @@ cart_top multi_mapper (
 	.prg_bus_write     (prg_bus_write),           // PRG data driven to bus
 	.prg_conflict      (prg_conflict),            // Simulate bus conflicts
 	.has_savestate     (mapper_has_savestate),    // Mapper supports savestates
-	.prg_conflict_d0  (prg_conflict_d0),        // Simulate bus conflicts for Mapper 144
+	.prg_conflict_d0   (prg_conflict_d0),         // Simulate bus conflicts for Mapper 144
+	.has_flashsaves    (has_flashsaves),          // Homebrew mapper that saves to PRG-ROM in flash memory
 	// User input/FDS controls
 	.fds_eject         (fds_eject),               // Used to trigger FDS disk changes
 	.fds_busy          (fds_busy),                // Used to trigger FDS disk changes


### PR DESCRIPTION
With thanks to Kitrinx for the challenge and a nudge in the right direction, this PR makes flash saves persistent by opening OSD like other saves, except these take a few seconds longer due to the size. 

I added a mapper flag `has_flashsaves`. When set to high, the core will treat `prg_rom` as save memory, making a full dump as a save file (since the save can be anywhere) without touching the installed rom. Made relevant signals larger to support 512KB saves. Added flash saves to mapper 111 and cleaned up my last commit to mapper 30 for better readability.

Fixes https://github.com/MiSTer-devel/NES_MiSTer/issues/282 and fixes https://github.com/MiSTer-devel/NES_MiSTer/issues/284