### PR TITLE
Mapper 64 (Rambo1): Fix irq (Klax)

### DIFF
--- a/rtl/mappers/MMC3.sv
+++ b/rtl/mappers/MMC3.sv
@@ -156,7 +156,6 @@ end else if (ce) begin
 			end else begin
 				counter <= 8'h00;
 			end
-
 			if (~|irq_latch && irq_enable) begin
 				irq_delay <= 1;
 			end


### PR DESCRIPTION
Rewrote irq according to nesdev wiki and nintendulator source. The glitches in Klax are gone, the other 2 games impacted (Hard Drivin and Skull & Crossbones) run fine.

Fixes https://github.com/MiSTer-devel/NES_MiSTer/issues/439