### PR TITLE
Mapper 141: Add 8KB unbanked CHR-RAM variant (Q boy), mapper 243: Fix CHR addressing (Honey Peach)

### DIFF
--- a/rtl/mappers/Sachen.sv
+++ b/rtl/mappers/Sachen.sv
@@ -89,9 +89,9 @@ end else if (ce && prg_write) begin
 			0: chr_bank_0 <= prg_din[2:0];  // Select 2 KB CHR bank at PPU $0000-$07FF;
 			1: chr_bank_1 <= prg_din[2:0];  // Select 2 KB CHR bank at PPU $0800-$0FFF;
 			2: begin
-			   chr_bank_2 <= prg_din[2:0];  // Select 2 KB CHR bank at PPU $1000-$17FF;
-				if (mapper150) prg_bank = {2'b00, prg_din[0]};
-				end
+			   		chr_bank_2 <= prg_din[2:0];  // Select 2 KB CHR bank at PPU $1000-$17FF;
+					if (mapper150) prg_bank = {2'b00, prg_din[0]};
+			   end
 			3: chr_bank_3 <= prg_din[2:0];  // Select 2 KB CHR bank at PPU $1800-$1FFF;
 			4: chr_bank_o <= prg_din[2:0];  // Outer CHR bank
 			5: prg_bank   <= prg_din[2:0];  // Select 32 KB PRG ROM bank at $8000-$FFFF;


### PR DESCRIPTION
The unlicensed Sachen game Q Boy seems to have a unique mapper. It is recognized by the wiki and emulators as mapper 141, while also recognizing the conflict in mapper specification and the need to switch to a different CHR config for this game specifically. This PR will enable the 8KB unbanked CHR-RAM this game needs when CHR-RAM flags are set in the header. This rom, and a few other 141 roms I checked, have their headers set correctly in the no-intro set.

Fixes https://github.com/MiSTer-devel/NES_MiSTer/issues/447

Also added the fix for mapper 243, only has one game. Fixes https://github.com/MiSTer-devel/NES_MiSTer/issues/446