### PR TITLE
Fix mapper 487 savestate support

### DIFF
--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -11,8 +11,8 @@
 // SDRAM Locations for various RAM types:
 // PRG       = 0....
 // CHR       = 10...
-// CHR-VRAM  = 1100
-// CPU-RAM   = 1110
+// CPU-RAM   = 11100
+// CHR-VRAM  = 11101
 // CARTRAM   = 1111
 
 module cart_top (
@@ -2176,6 +2176,44 @@ Mapper200 map200(
 );
 
 //*****************************************************************************//
+// Name   : AVE NINA-08                                                        //
+// Mappers: 487                                                                //
+// Status : Working                                                            //
+// Notes  : 30-in-1 multicart supporting NINA-03 and Color Dreams games        //
+// Games  : (Unreleased Maxivision 30-in-1 multicart)                          //
+//*****************************************************************************//
+Mapper487 map487(
+	.clk        (clk),
+	.ce         (ce),
+	.enable     (me[487]),
+	.flags      (flags),
+	.prg_ain    (prg_ain),
+	.prg_aout_b (prg_addr_b),
+	.prg_read   (prg_read),
+	.prg_write  (prg_write),
+	.prg_din    (prg_din),
+	.prg_dout_b (prg_dout_b),
+	.prg_allow_b(prg_allow_b),
+	.chr_ain    (chr_ain),
+	.chr_aout_b (chr_addr_b),
+	.chr_read   (chr_read),
+	.chr_allow_b(chr_allow_b),
+	.vram_a10_b (vram_a10_b),
+	.vram_ce_b  (vram_ce_b),
+	.irq_b      (irq_b),
+	.flags_out_b(flags_out_b),
+	.audio_in   (audio_in),
+	.audio_b    (audio_out_b),
+	// savestates
+	.SaveStateBus_Din  (SaveStateBus_Din ),
+	.SaveStateBus_Adr  (SaveStateBus_Adr ),
+	.SaveStateBus_wren (SaveStateBus_wren),
+	.SaveStateBus_rst  (SaveStateBus_rst ),
+	.SaveStateBus_load (SaveStateBus_load ),
+	.SaveStateBus_Dout (SaveStateBus_wired_or[39])
+);
+
+//*****************************************************************************//
 // Name   : Mapper 413                                                         //
 // Mappers: 413                                                                //
 // Status : Working                                                            //
@@ -2462,23 +2500,23 @@ always @* begin
 
 
 	// Remap the CHR address into VRAM, if needed.
-	chr_aout = vram_ce ? {11'b11_0000_0000_0, vram_a10, chr_ain[9:0]} : chr_aout;
+	chr_aout = vram_ce ? {11'b11_1010_0000_0, vram_a10, chr_ain[9:0]} : chr_aout;
 	prg_aout = (prg_ain < 'h2000) ? {11'b11_1000_0000_0, prg_ain[10:0]} : prg_aout;
 	prg_allow = prg_allow || (prg_ain < 'h2000);
 end
 
 // savestates
-localparam SAVESTATE_MODULES    = 39;
+localparam SAVESTATE_MODULES    = 40;
 wire [63:0] SaveStateBus_wired_or[0:SAVESTATE_MODULES-1];
 
 assign SaveStateBus_Dout  = SaveStateBus_wired_or[ 0] | SaveStateBus_wired_or[ 1] | SaveStateBus_wired_or[ 2] | SaveStateBus_wired_or[ 3] | SaveStateBus_wired_or[ 4] |
-									 SaveStateBus_wired_or[ 5] | SaveStateBus_wired_or[ 6] | SaveStateBus_wired_or[ 7] | SaveStateBus_wired_or[ 8] | SaveStateBus_wired_or[ 9] |
+									  SaveStateBus_wired_or[ 5] | SaveStateBus_wired_or[ 6] | SaveStateBus_wired_or[ 7] | SaveStateBus_wired_or[ 8] | SaveStateBus_wired_or[ 9] |
 									 SaveStateBus_wired_or[10] | SaveStateBus_wired_or[11] | SaveStateBus_wired_or[12] | SaveStateBus_wired_or[13] | SaveStateBus_wired_or[14] |
 									 SaveStateBus_wired_or[15] | SaveStateBus_wired_or[16] | SaveStateBus_wired_or[17] | SaveStateBus_wired_or[18] | SaveStateBus_wired_or[19] |
-									 SaveStateBus_wired_or[20] | SaveStateBus_wired_or[21] | SaveStateBus_wired_or[22] | SaveStateBus_wired_or[23] | SaveStateBus_wired_or[24] |
-									 SaveStateBus_wired_or[25] | SaveStateBus_wired_or[26] | SaveStateBus_wired_or[27] | SaveStateBus_wired_or[28] | SaveStateBus_wired_or[29] |
-									 SaveStateBus_wired_or[30] | SaveStateBus_wired_or[31] | SaveStateBus_wired_or[32] | SaveStateBus_wired_or[33] | SaveStateBus_wired_or[34] |
-									 SaveStateBus_wired_or[35] | SaveStateBus_wired_or[36] | SaveStateBus_wired_or[37] | SaveStateBus_wired_or[38];
+									  SaveStateBus_wired_or[20] | SaveStateBus_wired_or[21] | SaveStateBus_wired_or[22] | SaveStateBus_wired_or[23] | SaveStateBus_wired_or[24] |
+									  SaveStateBus_wired_or[25] | SaveStateBus_wired_or[26] | SaveStateBus_wired_or[27] | SaveStateBus_wired_or[28] | SaveStateBus_wired_or[29] |
+									  SaveStateBus_wired_or[30] | SaveStateBus_wired_or[31] | SaveStateBus_wired_or[32] | SaveStateBus_wired_or[33] | SaveStateBus_wired_or[34] |
+									  SaveStateBus_wired_or[35] | SaveStateBus_wired_or[36] | SaveStateBus_wired_or[37] | SaveStateBus_wired_or[38] | SaveStateBus_wired_or[39];
 
 localparam SAVESTATERAM_MODULES    = 4;
 wire [7:0] SaveStateRAM_wired_or[0:SAVESTATERAM_MODULES-1];

--- a/rtl/mappers/misc.sv
+++ b/rtl/mappers/misc.sv
@@ -2273,6 +2273,121 @@ assign vram_a10 = bank[3] ? chr_ain[11] : chr_ain[10]; // 1=horizontal, 0=vertic
 
 endmodule
 
+// #487 - AVE NINA-08 / Maxivision 30-in-1
+module Mapper487(
+	input        clk,         // System clock
+	input        ce,          // M2 ~cpu_clk
+	input        enable,      // Mapper enabled
+	input [31:0] flags,       // Cart flags
+	input [15:0] prg_ain,     // prg address
+	inout [21:0] prg_aout_b,  // prg address out
+	input        prg_read,    // prg read
+	input        prg_write,   // prg write
+	input  [7:0] prg_din,     // prg data in
+	inout  [7:0] prg_dout_b,  // prg data out
+	inout        prg_allow_b, // Enable access to memory for the specified operation.
+	input [13:0] chr_ain,     // chr address in
+	inout [21:0] chr_aout_b,  // chr address out
+	input        chr_read,    // chr ram read
+	inout        chr_allow_b, // chr allow write
+	inout        vram_a10_b,  // Value for A10 address line
+	inout        vram_ce_b,   // True if the address should be routed to the internal 2kB VRAM.
+	inout        irq_b,       // IRQ
+	input [15:0] audio_in,    // Inverted audio from APU
+	inout [15:0] audio_b,     // Mixed audio output
+	inout [15:0] flags_out_b, // flags {0, 0, 0, 0, has_savestate, prg_conflict, prg_bus_write, has_chr_dout}
+	// savestates
+	input       [63:0]  SaveStateBus_Din,
+	input       [ 9:0]  SaveStateBus_Adr,
+	input               SaveStateBus_wren,
+	input               SaveStateBus_rst,
+	input               SaveStateBus_load,
+	output      [63:0]  SaveStateBus_Dout
+);
+
+assign prg_aout_b   = enable ? prg_aout : 22'hZ;
+assign prg_dout_b   = enable ? 8'hFF : 8'hZ;
+assign prg_allow_b  = enable ? prg_allow : 1'hZ;
+assign chr_aout_b   = enable ? chr_aout : 22'hZ;
+assign chr_allow_b  = enable ? chr_allow : 1'hZ;
+assign vram_a10_b   = enable ? vram_a10 : 1'hZ;
+assign vram_ce_b    = enable ? vram_ce : 1'hZ;
+assign irq_b        = enable ? 1'b0 : 1'hZ;
+assign flags_out_b  = enable ? flags_out : 16'hZ;
+assign audio_b      = enable ? {1'b0, audio_in[15:1]} : 16'hZ;
+
+wire [21:0] prg_aout, chr_aout;
+wire prg_allow;
+wire chr_allow;
+wire vram_a10;
+wire vram_ce;
+wire [15:0] flags_out = {12'h0, 1'b1, 3'b00};
+
+// Outer bank register ($4180).
+// Bit 0 (b): PRG/CHR A15 when M=0
+// Bits 5-1: PRG/CHR bank high bits
+// Bit 5 (C): 0=NINA-03, 1=Color Dreams
+// Bit 6 (M): inner bank size, 0=32KB, 1=64KB
+// Bit 7 (N): mirroring
+reg [7:0] outer_bank;
+wire outer_b = outer_bank[0];
+wire chip_sel = outer_bank[5];
+wire inner_64k = outer_bank[6];
+wire mirroring = outer_bank[7];
+
+// NINA-03 ($4100-$417F): bits 0-1=CHR A14..A13, bit 2=CHR A15, bit 3=PRG A15.
+// Color Dreams ($8000-$FFFF): data bits reorganized as {D0, D6:D4}.
+reg [3:0] inner_bank;
+
+always @(posedge clk)
+if (~enable) begin
+	outer_bank <= 8'h00;
+	inner_bank <= 4'h0;
+end else if (SaveStateBus_load) begin
+	outer_bank <= SS_MAP1[7:0];
+	inner_bank <= SS_MAP1[11:8];
+end else if (ce && prg_write) begin
+	if (prg_ain[15:13] == 3'b010 && prg_ain[8]) begin
+		if (prg_ain[7]) begin
+			outer_bank <= prg_din;
+		end else if (!chip_sel) begin
+			inner_bank <= prg_din[3:0];
+		end
+	end else if (prg_ain[15] && chip_sel) begin
+		inner_bank <= {prg_din[0], prg_din[6:4]};
+	end
+end
+
+assign SS_MAP1_BACK[7:0] = outer_bank;
+assign SS_MAP1_BACK[11:8] = inner_bank;
+assign SS_MAP1_BACK[63:12] = 52'b0;
+
+wire prg_a15 = inner_64k ? inner_bank[3] : outer_b;
+wire [5:0] prg_raw = {outer_bank[5:1], prg_a15};
+wire [5:0] prg_bank = (prg_raw[5] | prg_raw[4]) ? (prg_raw - 6'd16) : prg_raw;
+
+wire chr_a15 = inner_64k ? inner_bank[2] : outer_b;
+wire [7:0] chr_raw = {outer_bank[5:1], chr_a15, inner_bank[1:0]};
+wire [7:0] chr_bank = (chr_raw[7] | chr_raw[6]) ? (chr_raw - 8'd64) : chr_raw;
+
+assign prg_aout = {1'b0, prg_bank, prg_ain[14:0]};
+assign prg_allow = prg_ain[15] && !prg_write;
+assign chr_aout = {1'b1, chr_bank, chr_ain[12:0]};
+assign chr_allow = flags[15];
+assign vram_ce = chr_ain[13];
+assign vram_a10 = mirroring ? chr_ain[11] : chr_ain[10];
+
+// savestate
+wire [63:0] SS_MAP1;
+wire [63:0] SS_MAP1_BACK;
+wire [63:0] SaveStateBus_Dout_active;
+
+eReg_SavestateV #(SSREG_INDEX_MAP1, 64'h0000000000000000) iREG_SAVESTATE_MAP1 (clk, SaveStateBus_Din, SaveStateBus_Adr, SaveStateBus_wren, SaveStateBus_rst, SaveStateBus_Dout_active, SS_MAP1_BACK, SS_MAP1);
+
+assign SaveStateBus_Dout = enable ? SaveStateBus_Dout_active : 64'h0000000000000000;
+
+endmodule
+
 // Combine with other mapper (15?)
 // #225 -  64-in-1
 // #255 -  110-in-1 - This runs with buggy menu selection.  It runs correctly as mapper 225.

--- a/rtl/savestates.vhd
+++ b/rtl/savestates.vhd
@@ -72,7 +72,7 @@ architecture arch of savestates is
       (16#000000#,     256),  -- OAM      -> internal
       (16#000000#,    8192),  -- MAPPER   -> internal
       (16#200000#, 1048576),  -- CHR      -> sdram
-      (16#300000#,    2048),  -- CHR-VRAM -> sdram
+      (16#3A0000#,    2048),  -- CHR-VRAM -> sdram
       (16#380000#,    2048),  -- CPU-RAM  -> sdram
       (16#3C0000#,  262144)   -- CARTRAM  -> sdram 
    );


### PR DESCRIPTION
Add Maxivision 30-in-1 mapper 487 support with mapper register savestate handling
 - Wired it into the cart savestate bus
 - Moved CHR-VRAM savestate backing out of the CPU-RAM range to avoid restore corruption

Tested with old Mike Tyson's Punchout save state

Please test with existing savestates
[NES_mapper487.zip](https://github.com/user-attachments/files/29661423/NES_mapper487.zip)
