### PR TITLE
MMC3: add 4KB PRG-RAM at $5000-$5FFF for mapper 195 (Waixing FS303)

### DIFF
--- a/rtl/mappers/MMC3.sv
+++ b/rtl/mappers/MMC3.sv
@@ -877,9 +877,15 @@ assign chr_aout =
 		(mapper52)                           ? {2'b10,         m52_chr_final, chr_ain[9:0]} : // Mapper 52 CHR override
 		                                       {3'b10_0,                chrsel, chr_ain[9:0]};    // Standard MMC3 CHR-ROM/RAM
 
-wire ram_a13 = mapper268 && m268_reg[3][5] && (prg_ain[15:12] == 4'h5);
-assign prg_is_ram = (ram_a13 || (prg_ain[15:13] == 3'b011) && ((prg_ain[12:8] == 5'b1_1111) | ~internal_128)) //(>= 'h6000 && < 'h8000) && (==7Fxx or external_ram)
-					&& ram_enable_a && !(ram_protect_a && prg_write);
+// Waixing FS303 (mapper 195) has 4KB of PRG-RAM at $5000-$5FFF, always
+// enabled and writable regardless of the MMC3 WRAM enable/protect bits.
+// Waixing originals/translations (e.g. Kyattou Ninden Teyandee (Ch))
+// use it as work RAM and freeze without it.
+wire ram_a13_195 = mapper195 && (prg_ain[15:12] == 4'h5);
+wire ram_a13 = (mapper268 && m268_reg[3][5] && (prg_ain[15:12] == 4'h5)) || ram_a13_195;
+assign prg_is_ram = ram_a13_195
+					|| ((ram_a13 || (prg_ain[15:13] == 3'b011) && ((prg_ain[12:8] == 5'b1_1111) | ~internal_128)) //(>= 'h6000 && < 'h8000) && (==7Fxx or external_ram)
+					&& ram_enable_a && !(ram_protect_a && prg_write));
 assign prg_allow = prg_ain[15] && !prg_write || (prg_is_ram && !mapper47 && !mapper208);
 wire [21:0] prg_ram = {8'b11_1100_00, ram_a13, internal_128 ? 6'b000000 : MMC6 ? {3'b000, prg_ain[9:7]} : prg_ain[12:7], prg_ain[6:0]};
 assign prg_aout = prg_is_ram  && !mapper47 && !mapper208 && !DxROM && !mapper95 && !mapper88 ? prg_ram : prg_aout_tmp;


### PR DESCRIPTION
## Summary

Mapper 195 (Waixing FS303) carts have 4KB of PRG-RAM at `$5000-$5FFF`, always enabled and writable independently of the MMC3 WRAM enable/protect bits (`$A001`). The current implementation covers the FS303 CHR-RAM behaviour (CHR banks 0-3 as 4KB CHR-RAM) but leaves `$5000-$5FFF` as open bus, so Waixing originals/translations that use this region as work RAM freeze shortly after boot (verified on hardware with *Kyattou Ninden Teyandee (Ch)* - the game deadlocks polling a `$5xxx` status variable that never changes).

This change reuses the existing `ram_a13` path (introduced for mapper 268) to map `$5000-$5FFF` to a distinct 4KB block of cartridge RAM (`0x3C3000`), bypassing the WRAM enable/protect gates for this window only. Mapper 268 behaviour is unchanged.

Reference: https://www.nesdev.org/wiki/INES_Mapper_195

## Testing

- Instruction-level simulation of the affected game against MiSTer MMC3 semantics (open bus at `$5xxx`) reproduces the freeze; with 4KB RAM at `$5000` (this patch's semantics) the game plays normally.
- Byte-exact frame comparison (10 checkpoints incl. dialogue screens) between the FS303 reference behaviour and the patched semantics shows no difference.
- Regular MMC3 (mapper 4) and mapper 268 address decoding paths are untouched apart from the added `ram_a13_195` term, which only asserts when `flags[7:0] == 195`.
